### PR TITLE
Added GitHub Workflow for running tests

### DIFF
--- a/.github/workflows/build-and-deploy-to-pages.yml
+++ b/.github/workflows/build-and-deploy-to-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-
   workflow_dispatch:
 
 permissions:
@@ -18,6 +17,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -41,6 +41,7 @@ jobs:
           path: ./build
 
   deploy:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: build
     environment:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,36 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run Playwright tests
+        run: npx playwright test
+      - name: Upload report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -2,5 +2,5 @@ import { expect, test } from '@playwright/test';
 
 test('index page has expected h1', async ({ page }) => {
 	await page.goto('/');
-	await expect(page.getByRole('heading', { name: 'Welcome to SvelteKit' })).toBeVisible();
+	await expect(page.getByRole('heading', { name: 'Petal Quest' })).toBeVisible();
 });


### PR DESCRIPTION
## What's in this PR?
I added a GitHub Workflow for running the Playwright tests. Right now, the test is very basic: it does a production build (`npm run build && npm run preview`) and confirms the heading on the main page has loaded. This will allow me to protect the main branch from pull requests that don't build successfully.

In the future, I plan to add more tests.

## 🐢
