### PR TITLE
Added Edit options for DragonConfig name and alignment

### DIFF
--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -119,7 +119,7 @@
 
 	{#if currentState === 'DISPLAY'}
 		<div class="w-fit">
-			<DragonControlButtons on:click={handleControlClick} />
+			<DragonControlButtons on:click={handleControlClick} on:resetDragon={onResetDragon} />
 		</div>
 	{/if}
 

--- a/src/lib/dragon/DragonControlButtons.svelte
+++ b/src/lib/dragon/DragonControlButtons.svelte
@@ -2,7 +2,7 @@
 	import { fade } from 'svelte/transition';
 	import { createEventDispatcher } from 'svelte';
 
-	const dispatch = createEventDispatcher<{ click: { buttonText: string } }>();
+	const dispatch = createEventDispatcher<{ click: { buttonText: string }; resetDragon: null }>();
 
 	function dispatchClick(buttonText: string) {
 		dispatch('click', {
@@ -20,7 +20,18 @@
 </script>
 
 <div transition:fade class="flex flex-wrap justify-center print:hidden">
-	<button class="daisy-btn daisy-btn-neutral m-1" on:click={dispatchClickEdit}>Edit Dragon</button>
-	<button class="daisy-btn daisy-btn-neutral m-1" on:click={dispatchClickShare}>Share Dragon</button
+	<button class="daisy-btn daisy-btn-neutral text-token m-1" on:click={dispatchClickEdit}>
+		Edit Dragon
+	</button>
+	<button class="daisy-btn daisy-btn-neutral text-token m-1" on:click={dispatchClickShare}>
+		Share Dragon
+	</button>
+	<button
+		class="daisy-btn daisy-btn-neutral text-token m-1"
+		on:click={() => {
+			dispatch('resetDragon');
+		}}
 	>
+		Build a New Dragon
+	</button>
 </div>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -56,6 +56,32 @@
 		</select>
 	</div>
 
+	<div class="daisy-form-control w-full max-w-xs m-1">
+		<label class="daisy-label" for="name">
+			<span class="daisy-label-text">Name</span>
+		</label>
+		<input
+			type="text"
+			bind:value={editedConfig.name}
+			class="daisy-input daisy-input-bordered bg-white"
+			name="name"
+			data-1p-ignore
+		/>
+	</div>
+
+	<div class="daisy-form-control w-full max-w-xs m-1">
+		<label class="daisy-label" for="alignment">
+			<span class="daisy-label-text">Alignment</span>
+		</label>
+		<input
+			type="text"
+			bind:value={editedConfig.alignment}
+			class="daisy-input daisy-input-bordered bg-white"
+			name="alignment"
+			data-1p-ignore
+		/>
+	</div>
+
 	<button class="daisy-btn daisy-btn-neutral m-2 mt-6 mb-1" on:click={updateDragon}>
 		Update Dragon
 	</button>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -57,7 +57,7 @@
 	</div>
 
 	<button class="daisy-btn daisy-btn-neutral m-2 mt-6 mb-1" on:click={updateDragon}>
-		Update the Dragon
+		Update Dragon
 	</button>
 
 	<button
@@ -66,6 +66,6 @@
 			dispatch('resetDragon');
 		}}
 	>
-		Reset the Dragon
+		Build a New Dragon
 	</button>
 </div>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -82,16 +82,7 @@
 		/>
 	</div>
 
-	<button class="daisy-btn daisy-btn-neutral m-2 mt-6 mb-1" on:click={updateDragon}>
+	<button class="daisy-btn daisy-btn-neutral m-2 mt-6" on:click={updateDragon}>
 		Update Dragon
-	</button>
-
-	<button
-		class="daisy-btn daisy-btn-neutral m-2 mt-1"
-		on:click={() => {
-			dispatch('resetDragon');
-		}}
-	>
-		Build a New Dragon
 	</button>
 </div>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -19,6 +19,7 @@
 		}
 	});
 	function updateDragon() {
+		editedConfig.cleanup();
 		dispatchDragonConfig(editedConfig);
 	}
 </script>
@@ -26,7 +27,7 @@
 <p class="font-bold text-xl">Edit</p>
 
 <div class="flex flex-col items-center">
-	<div class="daisy-form-control w-full max-w-xs m-1">
+	<div class="daisy-form-control w-full max-w-sm m-1">
 		<label class="daisy-label" for="age">
 			<span class="daisy-label-text">Age</span>
 		</label>
@@ -41,7 +42,7 @@
 		</select>
 	</div>
 
-	<div class="daisy-form-control w-full max-w-xs m-1">
+	<div class="daisy-form-control w-full max-w-sm m-1">
 		<label class="daisy-label" for="color">
 			<span class="daisy-label-text">Color</span>
 		</label>
@@ -56,26 +57,28 @@
 		</select>
 	</div>
 
-	<div class="daisy-form-control w-full max-w-xs m-1">
+	<div class="daisy-form-control w-full max-w-sm m-1">
 		<label class="daisy-label" for="name">
 			<span class="daisy-label-text">Name</span>
 		</label>
 		<input
 			type="text"
 			bind:value={editedConfig.name}
+			placeholder={'Referred to as "the dragon" by default'}
 			class="daisy-input daisy-input-bordered bg-white"
 			name="name"
 			data-1p-ignore
 		/>
 	</div>
 
-	<div class="daisy-form-control w-full max-w-xs m-1">
+	<div class="daisy-form-control w-full max-w-sm m-1">
 		<label class="daisy-label" for="alignment">
 			<span class="daisy-label-text">Alignment</span>
 		</label>
 		<input
 			type="text"
 			bind:value={editedConfig.alignment}
+			placeholder="Defaults to typical alignment for this color"
 			class="daisy-input daisy-input-bordered bg-white"
 			name="alignment"
 			data-1p-ignore

--- a/src/lib/dragon/builder-states/BuilderWelcome.svelte
+++ b/src/lib/dragon/builder-states/BuilderWelcome.svelte
@@ -50,6 +50,6 @@
 	</div>
 
 	<button class="daisy-btn daisy-btn-neutral m-2 mt-6" on:click={buildDragon}>
-		Build the Dragon
+		Build Dragon
 	</button>
 </div>

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -30,4 +30,17 @@ export class DragonConfig {
 	color: Color = 'red';
 	name?: string;
 	alignment?: string;
+
+	/**
+	 * Deletes unneeded members of this DragonConfig
+	 * @memberof DragonConfig
+	 */
+	cleanup(): void {
+		if (this.name === '') {
+			delete this.name;
+		}
+		if (this.alignment === '') {
+			delete this.alignment;
+		}
+	}
 }


### PR DESCRIPTION
## What's in this PR?
I've added text inputs which can be used to edit the DragonConfig's name and alignment. I also reworded the buttons and moved the "Build a New Dragon" button out to the control buttons.

## 🐢
