### PR TITLE
DragonBuilder now uses the URLSearchParams

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,3 @@ jobs:
         run: npx playwright install --with-deps
       - name: Run tests
         run: npm run test
-      - name: Upload report
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -16,8 +16,13 @@
 	import DragonControlButtons from './DragonControlButtons.svelte';
 	import DragonDebugButtons from './DragonDebugButtons.svelte';
 
+	// Builder State Management
 	let currentState: BuilderState = 'LOADING';
 	let nextState: BuilderState | undefined = undefined;
+
+	const fadeConfig: FadeParams = {
+		duration: 200
+	};
 
 	function setNextState(nextStateIn: BuilderState): void {
 		if (nextStateIn !== currentState) {
@@ -32,6 +37,7 @@
 		}
 	}
 
+	// Click Handling
 	function handleShareClick() {
 		openShareDialog();
 	}
@@ -63,25 +69,27 @@
 		}
 	}
 
+	// Dragon Config Management
 	let currentDragonConfig: DragonConfig | undefined = undefined;
 
-	onMount(() => {
-		setNextState('WELCOME');
-	});
+	function setCurrentDragonConfig(currentDragonConfigIn: DragonConfig | undefined): void {
+		currentDragonConfig = currentDragonConfigIn;
+	}
 
 	function onNewDragonConfig(event: { detail: DragonConfig }) {
-		currentDragonConfig = event.detail;
+		setCurrentDragonConfig(event.detail);
 		setNextState('DISPLAY');
 	}
 
 	function onResetDragon() {
 		setNextState('WELCOME');
-		currentDragonConfig = undefined;
+		setCurrentDragonConfig(undefined);
 	}
 
-	const fadeConfig: FadeParams = {
-		duration: 200
-	};
+	// Initialization
+	onMount(() => {
+		setNextState('WELCOME');
+	});
 </script>
 
 <div class="flex flex-col items-center">

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -5,7 +5,7 @@
 	import { fade, type FadeParams } from 'svelte/transition';
 	import { onMount } from 'svelte';
 
-	import type { DragonConfig } from '.';
+	import { DragonConfig } from '.';
 	import { type BuilderState, stringToBuilderState } from './builder-states';
 
 	import DragonContainer from './DragonContainer.svelte';
@@ -96,7 +96,13 @@
 
 	// Initialization
 	onMount(() => {
-		setNextState('WELCOME');
+		const URLDragonConfig = new DragonConfig();
+		if (URLDragonConfig.fromURLSearchParams($page.url.searchParams)) {
+			setCurrentDragonConfig(URLDragonConfig);
+			setNextState('DISPLAY');
+		} else {
+			setNextState('WELCOME');
+		}
 	});
 </script>
 

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { dev } from '$app/environment';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
 	import { fade, type FadeParams } from 'svelte/transition';
 	import { onMount } from 'svelte';
 
@@ -74,6 +76,12 @@
 
 	function setCurrentDragonConfig(currentDragonConfigIn: DragonConfig | undefined): void {
 		currentDragonConfig = currentDragonConfigIn;
+
+		if (currentDragonConfig === undefined) {
+			goto(`${$page.url.pathname}`);
+		} else {
+			goto(`?${currentDragonConfig.toString()}`);
+		}
 	}
 
 	function onNewDragonConfig(event: { detail: DragonConfig }) {
@@ -130,7 +138,7 @@
 	<DragonShareModal {currentDragonConfig} />
 
 	{#if currentState === 'DISPLAY' && nextState === undefined}
-		<div class="w-fit">
+		<div transition:fade={fadeConfig} class="w-fit">
 			<DragonControlButtons on:click={handleControlClick} on:resetDragon={onResetDragon} />
 		</div>
 	{/if}

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { dev } from '$app/environment';
-	import { fade } from 'svelte/transition';
+	import { fade, type FadeParams } from 'svelte/transition';
 	import { onMount } from 'svelte';
 
 	import type { DragonConfig } from '.';
@@ -78,24 +78,28 @@
 		setNextState('WELCOME');
 		currentDragonConfig = undefined;
 	}
+
+	const fadeConfig: FadeParams = {
+		duration: 200
+	};
 </script>
 
 <div class="flex flex-col items-center">
 	<DragonContainer config={currentDragonConfig}>
 		{#if currentState === 'LOADING' && nextState === undefined}
-			<div transition:fade on:outroend={finishStateTransition}>
+			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
 				<BuilderLoading />
 			</div>
 		{:else if currentState === 'WELCOME' && nextState === undefined}
-			<div transition:fade on:outroend={finishStateTransition}>
-				<BuilderWelcome on:newDragonConfig={onNewDragonConfig} />
+			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
+				<BuilderWelcome on:newDragonConfig={onNewDragonConfig} on:click={handleControlClick} />
 			</div>
 		{:else if currentState === 'DISPLAY' && nextState === undefined}
-			<div transition:fade on:outroend={finishStateTransition}>
+			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
 				<BuilderDisplay {currentDragonConfig} />
 			</div>
 		{:else if currentState === 'EDIT' && nextState === undefined}
-			<div transition:fade on:outroend={finishStateTransition}>
+			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
 				<BuilderEdit
 					{currentDragonConfig}
 					on:newDragonConfig={onNewDragonConfig}
@@ -103,13 +107,13 @@
 				/>
 			</div>
 		{:else if currentState === 'DEBUG' && nextState === undefined}
-			<div transition:fade on:outroend={finishStateTransition}>
+			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
 				<BuilderDebug {currentDragonConfig} />
 			</div>
 		{:else if nextState !== undefined}
 			<!-- We are transitioning. Keep it empty. -->
 		{:else}
-			<div transition:fade on:outroend={finishStateTransition}>
+			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
 				<p>The currentState of {currentState} is unhandled right now!</p>
 			</div>
 		{/if}
@@ -117,7 +121,7 @@
 
 	<DragonShareModal {currentDragonConfig} />
 
-	{#if currentState === 'DISPLAY'}
+	{#if currentState === 'DISPLAY' && nextState === undefined}
 		<div class="w-fit">
 			<DragonControlButtons on:click={handleControlClick} on:resetDragon={onResetDragon} />
 		</div>

--- a/src/lib/dragon/DragonContainer.svelte
+++ b/src/lib/dragon/DragonContainer.svelte
@@ -86,7 +86,7 @@
 	.outer-wrapper {
 		@apply overflow-hidden;
 		height: var(--outer-wrapper-height);
-		transition: height 250ms ease;
+		transition: height 200ms ease;
 	}
 
 	@media print {

--- a/src/lib/dragon/DragonControlButtons.svelte
+++ b/src/lib/dragon/DragonControlButtons.svelte
@@ -19,7 +19,7 @@
 	}
 </script>
 
-<div transition:fade class="flex flex-wrap justify-center print:hidden">
+<div class="flex flex-wrap justify-center print:hidden">
 	<button class="daisy-btn daisy-btn-neutral text-token m-1" on:click={dispatchClickEdit}>
 		Edit Dragon
 	</button>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -24,8 +24,6 @@
 	}
 </script>
 
-<p class="font-bold text-xl">Edit</p>
-
 <div class="flex flex-col items-center">
 	<div class="daisy-form-control w-full max-w-sm m-1">
 		<label class="daisy-label" for="age">
@@ -86,6 +84,6 @@
 	</div>
 
 	<button class="daisy-btn daisy-btn-neutral m-2 mt-6" on:click={updateDragon}>
-		Update Dragon
+		{currentDragonConfig === undefined ? 'Build' : 'Update'} Dragon
 	</button>
 </div>

--- a/src/lib/dragon/builder-states/BuilderWelcome.svelte
+++ b/src/lib/dragon/builder-states/BuilderWelcome.svelte
@@ -3,7 +3,10 @@
 
 	import { DragonConfig, AGES, AGES_UPPER, COLORS, COLORS_UPPER } from '..';
 
-	const dispatch = createEventDispatcher<{ newDragonConfig: DragonConfig }>();
+	const dispatch = createEventDispatcher<{
+		newDragonConfig: DragonConfig;
+		click: { buttonText: string };
+	}>();
 
 	function dispatchDragonConfig(newDragonConfig: DragonConfig) {
 		dispatch('newDragonConfig', newDragonConfig);
@@ -51,5 +54,16 @@
 
 	<button class="daisy-btn daisy-btn-neutral m-2 mt-6" on:click={buildDragon}>
 		Build Dragon
+	</button>
+
+	<button
+		class="daisy-btn daisy-btn-outline m-2"
+		on:click={() => {
+			dispatch('click', {
+				buttonText: 'EDIT'
+			});
+		}}
+	>
+		Advanced Options
 	</button>
 </div>

--- a/src/lib/dragon/builder-states/index.test.ts
+++ b/src/lib/dragon/builder-states/index.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest';
+import { stringToBuilderState, BUILDER_STATES } from '.';
+
+test('stringToBuilderState() behavior', () => {
+	expect(stringToBuilderState('This is not a valid builder state.')).toBe(undefined);
+
+	for (const state of BUILDER_STATES) {
+		expect(stringToBuilderState(state)).toBe(state);
+	}
+});

--- a/src/lib/dragon/builder-states/index.ts
+++ b/src/lib/dragon/builder-states/index.ts
@@ -1,5 +1,12 @@
 export const BUILDER_STATES = ['LOADING', 'WELCOME', 'DISPLAY', 'EDIT', 'DEBUG'] as const;
 export type BuilderState = (typeof BUILDER_STATES)[number];
+
+/**
+ * Converts input string to BuilderState if possible, returning undefined if not.
+ * @export
+ * @param {string} state_string
+ * @return {*}  {(BuilderState | undefined)}
+ */
 export function stringToBuilderState(state_string: string): BuilderState | undefined {
 	return BUILDER_STATES.find((state) => state === state_string);
 }

--- a/src/lib/dragon/index.test.ts
+++ b/src/lib/dragon/index.test.ts
@@ -1,5 +1,14 @@
 import { expect, test } from 'vitest';
-import { capitalizeFirstLetter, AGES_UPPER, COLORS_UPPER, DragonConfig } from '.';
+import {
+	capitalizeFirstLetter,
+	AGES,
+	AGES_UPPER,
+	stringToAge,
+	COLORS,
+	COLORS_UPPER,
+	stringToColor,
+	DragonConfig
+} from '.';
 
 test('capitalizeFirstLetter only does the first letter', () => {
 	expect(capitalizeFirstLetter('aa')).toBe('Aa');
@@ -13,6 +22,14 @@ test('AGES_UPPER are Wyrmling, Young, Adult, and Ancient', () => {
 	expect(AGES_UPPER).toStrictEqual(['Wyrmling', 'Young', 'Adult', 'Ancient']);
 });
 
+test('stringToAge() behavior', () => {
+	expect(stringToAge('This is not a valid age.')).toBe(undefined);
+
+	for (const age of AGES) {
+		expect(stringToAge(age)).toBe(age);
+	}
+});
+
 test('COLORS_UPPER are Red, Orange, Yellow, Green, Blue, Indigo, and Violet', () => {
 	expect(COLORS_UPPER).toStrictEqual([
 		'Red',
@@ -23,6 +40,14 @@ test('COLORS_UPPER are Red, Orange, Yellow, Green, Blue, Indigo, and Violet', ()
 		'Indigo',
 		'Violet'
 	]);
+});
+
+test('stringToColor() behavior', () => {
+	expect(stringToColor('This is not a valid color.')).toBe(undefined);
+
+	for (const color of COLORS) {
+		expect(stringToColor(color)).toBe(color);
+	}
 });
 
 test('DragonConfig.toString() behavior', () => {
@@ -42,4 +67,23 @@ test('DragonConfig.toString() behavior', () => {
 
 	dragonConfig.cleanup();
 	expect(dragonConfig.toString()).toBe(defaultString);
+});
+
+test('DragonConfig.fromURLSearchParams() behavior', () => {
+	const dragonConfig = new DragonConfig();
+	const params1 = new URLSearchParams();
+	expect(dragonConfig.fromURLSearchParams(params1)).toBe(false);
+
+	params1.set('age', 'young'); // valid age
+	params1.set('color', 'Jeremy'); // invalid color
+	expect(dragonConfig.fromURLSearchParams(params1)).toBe(false);
+
+	params1.append('color', 'blue'); // valid color, appended after invalid color
+	expect(dragonConfig.fromURLSearchParams(params1)).toBe(false);
+
+	params1.set('color', 'blue'); // valid color, replacing all other color values
+	expect(dragonConfig.fromURLSearchParams(params1)).toBe(true);
+
+	params1.append('color', 'Jeremy'); // invalid color, appended after valid color
+	expect(dragonConfig.fromURLSearchParams(params1)).toBe(true);
 });

--- a/src/lib/dragon/index.test.ts
+++ b/src/lib/dragon/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { capitalizeFirstLetter, AGES_UPPER, COLORS_UPPER } from '.';
+import { capitalizeFirstLetter, AGES_UPPER, COLORS_UPPER, DragonConfig } from '.';
 
 test('capitalizeFirstLetter only does the first letter', () => {
 	expect(capitalizeFirstLetter('aa')).toBe('Aa');
@@ -23,4 +23,23 @@ test('COLORS_UPPER are Red, Orange, Yellow, Green, Blue, Indigo, and Violet', ()
 		'Indigo',
 		'Violet'
 	]);
+});
+
+test('DragonConfig.toString() behavior', () => {
+	const dragonConfig = new DragonConfig();
+	const defaultString = 'age=wyrmling&color=red';
+	expect(dragonConfig.toString()).toBe(defaultString);
+
+	const testName = 'Amara';
+	const testAlignment = 'Chaotic';
+	dragonConfig.name = testName;
+	dragonConfig.alignment = testAlignment;
+	expect(dragonConfig.toString()).toBe(`${defaultString}&name=Amara&alignment=Chaotic`);
+
+	dragonConfig.name = '';
+	dragonConfig.alignment = '';
+	expect(dragonConfig.toString()).toBe(`${defaultString}&name=&alignment=`);
+
+	dragonConfig.cleanup();
+	expect(dragonConfig.toString()).toBe(defaultString);
 });

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -32,7 +32,7 @@ export class DragonConfig {
 	alignment?: string;
 
 	/**
-	 * Deletes unneeded members of this DragonConfig
+	 * Deletes unneeded members of this DragonConfig.
 	 * @memberof DragonConfig
 	 */
 	cleanup(): void {
@@ -42,5 +42,34 @@ export class DragonConfig {
 		if (this.alignment === '') {
 			delete this.alignment;
 		}
+	}
+
+	/**
+	 * Returns a URLSearchParams containing all defined members of this DragonConfig.
+	 * @return {*}  {URLSearchParams}
+	 * @memberof DragonConfig
+	 */
+	toURLSearchParams(): URLSearchParams {
+		const output = new URLSearchParams();
+
+		output.set('age', this.age);
+		output.set('color', this.color);
+		if (this.name !== undefined) {
+			output.set('name', this.name);
+		}
+		if (this.alignment !== undefined) {
+			output.set('alignment', this.alignment);
+		}
+
+		return output;
+	}
+
+	/**
+	 * Returns a query string version of this DragonConfig suitable for a URL. Does not include the question mark.
+	 * @return {*}  {string}
+	 * @memberof DragonConfig
+	 */
+	toString(): string {
+		return this.toURLSearchParams().toString();
 	}
 }

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -7,10 +7,30 @@ export const AGES_UPPER = AGES.map(capitalizeFirstLetter) as ReadonlyArray<strin
 export const AGES_CAPS = AGES.map((age) => age.toUpperCase()) as ReadonlyArray<string>;
 export type Age = (typeof AGES)[number];
 
+/**
+ * Converts input string to Age if possible, returning undefined if not.
+ * @export
+ * @param {string} age_string
+ * @return {*}  {(Age | undefined)}
+ */
+export function stringToAge(age_string: string): Age | undefined {
+	return AGES.find((age) => age === age_string);
+}
+
 export const COLORS = ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'] as const;
 export const COLORS_UPPER = COLORS.map(capitalizeFirstLetter) as ReadonlyArray<string>;
 export const COLORS_CAPS = COLORS.map((color) => color.toUpperCase()) as ReadonlyArray<string>;
 export type Color = (typeof COLORS)[number];
+
+/**
+ * Converts input string to Color if possible, returning undefined if not.
+ * @export
+ * @param {string} color_string
+ * @return {*}  {(Color | undefined)}
+ */
+export function stringToColor(color_string: string): Color | undefined {
+	return COLORS.find((color) => color === color_string);
+}
 
 export type RGB = `rgb(${number}, ${number}, ${number})`;
 export const COLOR_TO_THEME: {
@@ -71,5 +91,41 @@ export class DragonConfig {
 	 */
 	toString(): string {
 		return this.toURLSearchParams().toString();
+	}
+
+	/**
+	 * If given params have valid DragonConfig values, sets this DragonConfig from them and returns true.
+	 * @param {URLSearchParams} params
+	 * @return {*}  {boolean} If given params have valid DragonConfig values, true. Otherwise false.
+	 * @memberof DragonConfig
+	 */
+	fromURLSearchParams(params: URLSearchParams): boolean {
+		// The params must contain a valid age and color to be used.
+		const paramsAgeVal = params.get('age');
+		const paramsColorVal = params.get('color');
+		if (paramsAgeVal === null || paramsColorVal === null) {
+			return false;
+		}
+
+		const paramsAge = stringToAge(paramsAgeVal);
+		const paramsColor = stringToColor(paramsColorVal);
+		if (paramsAge === undefined || paramsColor === undefined) {
+			return false;
+		}
+
+		this.age = paramsAge;
+		this.color = paramsColor;
+
+		const paramsNameVal = params.get('name');
+		if (paramsNameVal !== null) {
+			this.name = paramsNameVal;
+		}
+
+		const paramsAlignmentVal = params.get('alignment');
+		if (paramsAlignmentVal !== null) {
+			this.alignment = paramsAlignmentVal;
+		}
+
+		return true;
 	}
 }


### PR DESCRIPTION
## What's in this PR?
This PR updates the DragonBuilder with some key functionality: the ability to **get** the DragonConfig from the URL and **set** the URL from the DragonConfig.

There are some miscellaneous improvements in here as well:
- DragonBuilder transitions are faster, and the DragonControlButtons start fading when they should.
- The DragonContainer height transition duration is now the same as the fade duration.
- I removed a step from the GitHub Actions that was trying to upload files that didn't exist.
- You can now go straight to the EDIT state from WELCOME, and the button says the right thing ("Build Dragon" instead of "Update Dragon"). The EDIT page also no longer says "Edit" at the top.
- Added utility functions for converting strings to Age or Color, plus tests to cover them.
- `stringToBuilderState()` now has documentation and testing coverage.

## 🐢
