### PR TITLE
Improved DragonBuilder behavior with refresh + back/forward buttons

### DIFF
--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -80,7 +80,10 @@
 		if (currentDragonConfig === undefined) {
 			goto(`${$page.url.pathname}`);
 		} else {
-			goto(`?${currentDragonConfig.toString()}`);
+			const configSearchString = `?${currentDragonConfig.toString()}`;
+			if (configSearchString !== $page.url.search) {
+				goto(configSearchString);
+			}
 		}
 	}
 

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 	import { dev } from '$app/environment';
-	import { goto } from '$app/navigation';
+	import { goto, afterNavigate } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { fade, type FadeParams } from 'svelte/transition';
-	import { onMount } from 'svelte';
 
 	import { DragonConfig } from '.';
 	import { type BuilderState, stringToBuilderState } from './builder-states';
@@ -98,7 +97,7 @@
 	}
 
 	// Initialization
-	onMount(() => {
+	afterNavigate(() => {
 		const URLDragonConfig = new DragonConfig();
 		if (URLDragonConfig.fromURLSearchParams($page.url.searchParams)) {
 			setCurrentDragonConfig(URLDragonConfig);


### PR DESCRIPTION
## What's in this PR?
With the last update, a history entry would be added every time the DragonBuilder was refreshed. Additionally, navigating back/forward wouldn't trigger an update of the DragonBuilder. Both of those issues are now fixed!

There's still some weirdness if you double-click the back/forward buttons in quick succession, but these improvements shouldn't have to wait for me to fix that smaller issue.

## 🐢
