### PR TITLE
Dragon Builder History added + other misc improvements

### DIFF
--- a/src/lib/Drawer.svelte
+++ b/src/lib/Drawer.svelte
@@ -22,7 +22,7 @@
 <Drawer position="right" width="w-[280px] md:w-[480px]">
 	<div class="px-4 flex justify-between flex-row">
 		<div />
-		<button class="close-btn hover:bg-surface-hover-token" on:click={drawerClose}>
+		<button class="close-btn hover:bg-primary-hover-token" on:click={drawerClose}>
 			<span>
 				<svg class="w-5 h-5" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
 					<path
@@ -41,7 +41,7 @@
 			{#each NAV_LINKS as link}
 				<li>
 					<a
-						class="nav-anchor hover:bg-surface-hover-token"
+						class="nav-anchor hover:bg-primary-hover-token"
 						class:active={path === link.href}
 						href={link.href}
 						on:click={drawerClose}

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -25,7 +25,7 @@
 					{#each NAV_LINKS as link}
 						<li>
 							<a
-								class="nav-anchor hover:bg-surface-hover-token"
+								class="nav-anchor hover:bg-primary-hover-token"
 								class:active={path === link.href}
 								href={link.href}
 							>
@@ -35,7 +35,7 @@
 					{/each}
 				</ul>
 			</nav>
-			<button class="lg:hidden menu-btn hover:bg-surface-hover-token" on:click={drawerOpen}>
+			<button class="lg:hidden menu-btn hover:bg-primary-hover-token" on:click={drawerOpen}>
 				<span>
 					<svg viewBox="0 0 80 80" class="fill-token w-5 h-5">
 						<rect y="0" width="80" height="10" rx="2" />

--- a/src/lib/Logo.svelte
+++ b/src/lib/Logo.svelte
@@ -11,7 +11,7 @@
 <a
 	href="/"
 	aria-label="Home"
-	class="logo-anchor hover:bg-surface-hover-token"
+	class="logo-anchor hover:bg-primary-hover-token"
 	on:click={dispatchClick}
 >
 	<img src="favicon.png" alt="Petal Quest logo" class="logo-img" />

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -86,9 +86,6 @@
 		if ($currentDragonConfig !== undefined) {
 			const currentConfigString = $currentDragonConfig.toString();
 
-			// add this config to the Builder History
-			dragonBuilderHistory.add($currentDragonConfig);
-
 			// update the current URL search params to match this config
 			const configSearchString = `?${currentConfigString}`;
 			if (redirect && configSearchString !== $page.url.search) {

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -85,8 +85,8 @@
 		if ($currentDragonConfig !== undefined) {
 			const currentConfigString = $currentDragonConfig.toString();
 
-			// add this config string to the Builder History
-			dragonBuilderHistory.add(currentConfigString);
+			// add this config to the Builder History
+			dragonBuilderHistory.add($currentDragonConfig);
 
 			// update the current URL search params to match this config
 			const configSearchString = `?${currentConfigString}`;

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -101,6 +101,10 @@
 			if (redirect && configSearchString !== $page.url.search) {
 				goto(configSearchString);
 			}
+		} else {
+			if (redirect) {
+				goto($page.url.pathname);
+			}
 		}
 	}
 

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -2,10 +2,15 @@
 	import { dev } from '$app/environment';
 	import { afterNavigate } from '$app/navigation';
 	import { page } from '$app/stores';
-	import { fade, type FadeParams } from 'svelte/transition';
+	import { fade } from 'svelte/transition';
 
 	import { DragonConfig } from '.';
-	import { type BuilderState, stringToBuilderState, currentDragonConfig } from './builder-states';
+	import {
+		type BuilderState,
+		stringToBuilderState,
+		currentDragonConfig,
+		builderFadeParams
+	} from './builder-states';
 
 	import DragonContainer from './DragonContainer.svelte';
 	import BuilderLoading from './builder-states/BuilderLoading.svelte';
@@ -21,10 +26,6 @@
 	// Builder State Management
 	let currentState: BuilderState = 'LOADING';
 	let nextState: BuilderState | undefined = undefined;
-
-	const fadeConfig: FadeParams = {
-		duration: 200
-	};
 
 	function setNextState(nextStateIn: BuilderState): void {
 		if (nextStateIn !== currentState) {
@@ -87,33 +88,33 @@
 <div class="flex flex-col items-center">
 	<DragonContainer config={$currentDragonConfig}>
 		{#if currentState === 'LOADING' && nextState === undefined}
-			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
+			<div transition:fade={builderFadeParams} on:outroend={finishStateTransition}>
 				<BuilderLoading />
 			</div>
 		{:else if currentState === 'WELCOME' && nextState === undefined}
-			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
+			<div transition:fade={builderFadeParams} on:outroend={finishStateTransition}>
 				<BuilderWelcome on:click={handleControlClick} />
 			</div>
 		{:else if currentState === 'DISPLAY' && nextState === undefined}
-			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
+			<div transition:fade={builderFadeParams} on:outroend={finishStateTransition}>
 				<BuilderDisplay />
 			</div>
 		{:else if currentState === 'EDIT' && nextState === undefined}
-			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
+			<div transition:fade={builderFadeParams} on:outroend={finishStateTransition}>
 				<BuilderEdit />
 			</div>
 		{:else if currentState === 'HISTORY' && nextState === undefined}
-			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
+			<div transition:fade={builderFadeParams} on:outroend={finishStateTransition}>
 				<BuilderHistory />
 			</div>
 		{:else if currentState === 'DEBUG' && nextState === undefined}
-			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
+			<div transition:fade={builderFadeParams} on:outroend={finishStateTransition}>
 				<BuilderDebug />
 			</div>
 		{:else if nextState !== undefined}
 			<!-- We are transitioning. Keep it empty. -->
 		{:else}
-			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
+			<div transition:fade={builderFadeParams} on:outroend={finishStateTransition}>
 				<p>The currentState of {currentState} is unhandled right now!</p>
 			</div>
 		{/if}
@@ -122,7 +123,7 @@
 	<DragonShareModal config={$currentDragonConfig} />
 
 	{#if currentState === 'DISPLAY' && nextState === undefined}
-		<div transition:fade={fadeConfig} class="w-fit">
+		<div transition:fade={builderFadeParams} class="w-fit">
 			<DragonControlButtons on:click={handleControlClick} />
 		</div>
 	{/if}

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -48,6 +48,8 @@
 	function handleControlClick(event: { detail: { buttonText: string } }): void {
 		if (event.detail.buttonText === 'EDIT') {
 			setNextState('EDIT');
+		} else if (event.detail.buttonText === 'HISTORY') {
+			setNextState('HISTORY');
 		} else if (event.detail.buttonText === 'SHARE') {
 			handleShareClick();
 		} else {
@@ -55,7 +57,7 @@
 		}
 	}
 
-	const debugEnabled: boolean = true && dev;
+	const debugEnabled: boolean = false && dev;
 
 	function handleDebugClick(event: { detail: { debugText: string } }): void {
 		if (debugEnabled) {

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -6,6 +6,7 @@
 
 	import { DragonConfig } from '.';
 	import { type BuilderState, stringToBuilderState } from './builder-states';
+	import { dragonBuilderHistory } from './builder-history';
 
 	import DragonContainer from './DragonContainer.svelte';
 	import BuilderLoading from './builder-states/BuilderLoading.svelte';
@@ -72,13 +73,32 @@
 
 	// Dragon Config Management
 	let currentDragonConfig: DragonConfig | undefined = undefined;
+	let pastConfigStrings: string[] = [];
+
+	dragonBuilderHistory.subscribe((value) => {
+		pastConfigStrings = value;
+	});
 
 	function setCurrentDragonConfig(currentDragonConfigIn: DragonConfig | undefined): void {
 		currentDragonConfig = currentDragonConfigIn;
 
 		if (currentDragonConfig !== undefined) {
+			const currentConfigString = currentDragonConfig.toString();
+
+			// check to see if this config is the latest config in builder history
+			const configIndexInHistory = pastConfigStrings.findIndex((configString: string) => {
+				return configString === currentConfigString;
+			});
+			if (configIndexInHistory !== 0) {
+				if (configIndexInHistory > 0) {
+					pastConfigStrings.splice(configIndexInHistory, 1);
+				}
+				pastConfigStrings.unshift(currentConfigString);
+				dragonBuilderHistory.set(pastConfigStrings);
+			}
+
 			// update the current URL search params to match this config
-			const configSearchString = `?${currentDragonConfig.toString()}`;
+			const configSearchString = `?${currentConfigString}`;
 			if (configSearchString !== $page.url.search) {
 				goto(configSearchString);
 			}

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -85,16 +85,8 @@
 		if ($currentDragonConfig !== undefined) {
 			const currentConfigString = $currentDragonConfig.toString();
 
-			// check to see if this config is the latest config in builder history
-			const configIndexInHistory = $dragonBuilderHistory.findIndex((configString: string) => {
-				return configString === currentConfigString;
-			});
-			if (configIndexInHistory !== 0) {
-				if (configIndexInHistory > 0) {
-					$dragonBuilderHistory.splice(configIndexInHistory, 1);
-				}
-				$dragonBuilderHistory.unshift(currentConfigString);
-			}
+			// add this config string to the Builder History
+			dragonBuilderHistory.add(currentConfigString);
 
 			// update the current URL search params to match this config
 			const configSearchString = `?${currentConfigString}`;

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -76,9 +76,8 @@
 	function setCurrentDragonConfig(currentDragonConfigIn: DragonConfig | undefined): void {
 		currentDragonConfig = currentDragonConfigIn;
 
-		if (currentDragonConfig === undefined) {
-			goto(`${$page.url.pathname}`);
-		} else {
+		if (currentDragonConfig !== undefined) {
+			// update the current URL search params to match this config
 			const configSearchString = `?${currentDragonConfig.toString()}`;
 			if (configSearchString !== $page.url.search) {
 				goto(configSearchString);
@@ -104,6 +103,7 @@
 			setNextState('DISPLAY');
 		} else {
 			setNextState('WELCOME');
+			setCurrentDragonConfig(undefined);
 		}
 	});
 </script>

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
 	import { dev } from '$app/environment';
-	import { goto, afterNavigate } from '$app/navigation';
+	import { afterNavigate } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { fade, type FadeParams } from 'svelte/transition';
 
 	import { DragonConfig } from '.';
-	import {
-		type BuilderState,
-		stringToBuilderState,
-		dragonBuilderHistory,
-		currentDragonConfig
-	} from './builder-states';
+	import { type BuilderState, stringToBuilderState, currentDragonConfig } from './builder-states';
 
 	import DragonContainer from './DragonContainer.svelte';
 	import BuilderLoading from './builder-states/BuilderLoading.svelte';
@@ -76,47 +71,15 @@
 		}
 	}
 
-	// Dragon Config Management
-	function setCurrentDragonConfig(
-		newConfig: DragonConfig | undefined,
-		redirect: boolean = true
-	): void {
-		$currentDragonConfig = newConfig;
-
-		if ($currentDragonConfig !== undefined) {
-			const currentConfigString = $currentDragonConfig.toString();
-
-			// update the current URL search params to match this config
-			const configSearchString = `?${currentConfigString}`;
-			if (redirect && configSearchString !== $page.url.search) {
-				goto(configSearchString);
-			}
-		} else {
-			if (redirect) {
-				goto($page.url.pathname);
-			}
-		}
-	}
-
-	function onNewDragonConfig(event: { detail: DragonConfig }) {
-		setCurrentDragonConfig(event.detail);
-		setNextState('DISPLAY');
-	}
-
-	function onResetDragon() {
-		setNextState('WELCOME');
-		setCurrentDragonConfig(undefined);
-	}
-
-	// Initialization
+	// Initialization / Dragon Config Management
 	afterNavigate(() => {
 		const URLDragonConfig = new DragonConfig();
 		if (URLDragonConfig.fromURLSearchParams($page.url.searchParams)) {
-			setCurrentDragonConfig(URLDragonConfig, false);
+			currentDragonConfig.set(URLDragonConfig, true);
 			setNextState('DISPLAY');
 		} else {
 			setNextState('WELCOME');
-			setCurrentDragonConfig(undefined, false);
+			currentDragonConfig.set(undefined, true);
 		}
 	});
 </script>
@@ -129,7 +92,7 @@
 			</div>
 		{:else if currentState === 'WELCOME' && nextState === undefined}
 			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
-				<BuilderWelcome on:newDragonConfig={onNewDragonConfig} on:click={handleControlClick} />
+				<BuilderWelcome on:click={handleControlClick} />
 			</div>
 		{:else if currentState === 'DISPLAY' && nextState === undefined}
 			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
@@ -137,7 +100,7 @@
 			</div>
 		{:else if currentState === 'EDIT' && nextState === undefined}
 			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
-				<BuilderEdit on:newDragonConfig={onNewDragonConfig} on:resetDragon={onResetDragon} />
+				<BuilderEdit />
 			</div>
 		{:else if currentState === 'HISTORY' && nextState === undefined}
 			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
@@ -160,7 +123,7 @@
 
 	{#if currentState === 'DISPLAY' && nextState === undefined}
 		<div transition:fade={fadeConfig} class="w-fit">
-			<DragonControlButtons on:click={handleControlClick} on:resetDragon={onResetDragon} />
+			<DragonControlButtons on:click={handleControlClick} />
 		</div>
 	{/if}
 

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -17,6 +17,7 @@
 	import BuilderWelcome from './builder-states/BuilderWelcome.svelte';
 	import BuilderDisplay from './builder-states/BuilderDisplay.svelte';
 	import BuilderEdit from './builder-states/BuilderEdit.svelte';
+	import BuilderHistory from './builder-states/BuilderHistory.svelte';
 	import BuilderDebug from './builder-states/BuilderDebug.svelte';
 	import DragonShareModal, { openShareDialog } from './DragonShareModal.svelte';
 	import DragonControlButtons from './DragonControlButtons.svelte';
@@ -58,7 +59,7 @@
 		}
 	}
 
-	const debugEnabled: boolean = false && dev;
+	const debugEnabled: boolean = true && dev;
 
 	function handleDebugClick(event: { detail: { debugText: string } }): void {
 		if (debugEnabled) {
@@ -140,6 +141,10 @@
 		{:else if currentState === 'EDIT' && nextState === undefined}
 			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
 				<BuilderEdit on:newDragonConfig={onNewDragonConfig} on:resetDragon={onResetDragon} />
+			</div>
+		{:else if currentState === 'HISTORY' && nextState === undefined}
+			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>
+				<BuilderHistory />
 			</div>
 		{:else if currentState === 'DEBUG' && nextState === undefined}
 			<div transition:fade={fadeConfig} on:outroend={finishStateTransition}>

--- a/src/lib/dragon/DragonConfigPreview.svelte
+++ b/src/lib/dragon/DragonConfigPreview.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import type { DragonConfig } from '.';
+
+	export let config: DragonConfig;
+</script>
+
+<p>Config = {JSON.stringify(config)}</p>

--- a/src/lib/dragon/DragonConfigPreview.svelte
+++ b/src/lib/dragon/DragonConfigPreview.svelte
@@ -1,7 +1,33 @@
 <script lang="ts">
-	import type { DragonConfig } from '.';
+	import { type DragonConfig, RGBToRGBA } from '.';
 
 	export let config: DragonConfig;
 </script>
 
-<p>Config = {JSON.stringify(config)}</p>
+<div
+	class="daisy-card daisy-card-compact m-1 w-full max-w-xl shadow-xl"
+	style="background: {RGBToRGBA(config.getTheme(), 0.1)};"
+>
+	<div class="daisy-card-body">
+		<h2 class="daisy-card-title">{config.getTitle()}</h2>
+		<p>{config.toString()}</p>
+		<div class="daisy-card-actions justify-end">
+			<button
+				class="daisy-btn daisy-btn-outline hover:daisy-btn-error"
+				on:click={() => {
+					console.log('You clicked delete!');
+				}}
+			>
+				Delete Dragon
+			</button>
+			<button
+				class="daisy-btn daisy-btn-neutral text-white"
+				on:click={() => {
+					console.log('You clicked rebuild!');
+				}}
+			>
+				Rebuild Dragon
+			</button>
+		</div>
+	</div>
+</div>

--- a/src/lib/dragon/DragonConfigPreview.svelte
+++ b/src/lib/dragon/DragonConfigPreview.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
 	import { type DragonConfig, RGBToRGBA } from '.';
+	import { currentDragonConfig } from './builder-states';
+
+	const dispatch = createEventDispatcher<{ clickDelete: DragonConfig }>();
 
 	export let config: DragonConfig;
 </script>
@@ -15,7 +19,7 @@
 			<button
 				class="daisy-btn daisy-btn-outline hover:daisy-btn-error"
 				on:click={() => {
-					console.log('You clicked delete!');
+					dispatch('clickDelete', config);
 				}}
 			>
 				Delete Dragon
@@ -23,7 +27,7 @@
 			<button
 				class="daisy-btn daisy-btn-neutral text-white"
 				on:click={() => {
-					console.log('You clicked rebuild!');
+					$currentDragonConfig = config;
 				}}
 			>
 				Rebuild Dragon

--- a/src/lib/dragon/DragonContainer.svelte
+++ b/src/lib/dragon/DragonContainer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { type RGB, COLOR_TO_THEME, COLORS, DragonConfig } from '.';
+	import { builderFadeParams } from './builder-states';
 	export let config: DragonConfig | undefined = undefined;
 	let dragonTheme: RGB;
 
@@ -34,7 +35,7 @@
 	<div class="dragon-container-top-edge" />
 	<div
 		class="outer-wrapper"
-		style="--outer-wrapper-height: {outerWrapperHeight}px; min-height: {minHeight}px;"
+		style="--outer-wrapper-height: {outerWrapperHeight}px; min-height: {minHeight}px; transition: height {builderFadeParams.duration}ms ease;"
 		data-theme="statBlockContents"
 	>
 		<div class="inner-wrapper" bind:clientHeight={innerClientHeight}>
@@ -86,7 +87,6 @@
 	.outer-wrapper {
 		@apply overflow-hidden;
 		height: var(--outer-wrapper-height);
-		transition: height 200ms ease;
 	}
 
 	@media print {

--- a/src/lib/dragon/DragonContainer.svelte
+++ b/src/lib/dragon/DragonContainer.svelte
@@ -18,7 +18,7 @@
 	$: if (config == undefined) {
 		dragonTheme = COLOR_TO_THEME[COLORS[iColor]];
 	} else {
-		dragonTheme = COLOR_TO_THEME[config.color];
+		dragonTheme = config.getTheme();
 	}
 
 	let innerClientHeight: number;

--- a/src/lib/dragon/DragonControlButtons.svelte
+++ b/src/lib/dragon/DragonControlButtons.svelte
@@ -1,35 +1,38 @@
 <script lang="ts">
-	import { fade } from 'svelte/transition';
 	import { createEventDispatcher } from 'svelte';
 
-	const dispatch = createEventDispatcher<{ click: { buttonText: string }; resetDragon: null }>();
+	import { currentDragonConfig } from './builder-states';
+
+	const dispatch = createEventDispatcher<{ click: { buttonText: string } }>();
 
 	function dispatchClick(buttonText: string) {
 		dispatch('click', {
 			buttonText: buttonText
 		});
 	}
-
-	function dispatchClickEdit() {
-		dispatchClick('EDIT');
-	}
-
-	function dispatchClickShare() {
-		dispatchClick('SHARE');
-	}
 </script>
 
 <div class="flex flex-wrap justify-center print:hidden">
-	<button class="daisy-btn daisy-btn-neutral text-token m-1" on:click={dispatchClickEdit}>
+	<button
+		class="daisy-btn daisy-btn-neutral text-token m-1"
+		on:click={() => {
+			dispatchClick('EDIT');
+		}}
+	>
 		Edit Dragon
 	</button>
-	<button class="daisy-btn daisy-btn-neutral text-token m-1" on:click={dispatchClickShare}>
+	<button
+		class="daisy-btn daisy-btn-neutral text-token m-1"
+		on:click={() => {
+			dispatchClick('SHARE');
+		}}
+	>
 		Share Dragon
 	</button>
 	<button
 		class="daisy-btn daisy-btn-neutral text-token m-1"
 		on:click={() => {
-			dispatch('resetDragon');
+			$currentDragonConfig = undefined;
 		}}
 	>
 		Build a New Dragon

--- a/src/lib/dragon/DragonShareModal.svelte
+++ b/src/lib/dragon/DragonShareModal.svelte
@@ -9,7 +9,7 @@
 <script lang="ts">
 	import type { DragonConfig } from '.';
 
-	export let currentDragonConfig: DragonConfig | undefined;
+	export let config: DragonConfig | undefined;
 </script>
 
 <dialog bind:this={shareDialog} class="daisy-modal daisy-modal-bottom sm:daisy-modal-middle">
@@ -17,9 +17,7 @@
 		<h3 class="font-bold text-lg">Hello!</h3>
 		<p>
 			This is the WIP dragon share modal. Eventually there will be buttons you can press for
-			printing or copying the sharable URL. For now, here's the currentDragonConfig: {JSON.stringify(
-				currentDragonConfig
-			)}.
+			printing or copying the sharable URL. For now, here's the config: {JSON.stringify(config)}.
 		</p>
 		<p>Press ESC key or click the button below to close</p>
 		<div class="daisy-modal-action">

--- a/src/lib/dragon/builder-history.ts
+++ b/src/lib/dragon/builder-history.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const dragonBuilderHistory = writable<string[]>([]);

--- a/src/lib/dragon/builder-history.ts
+++ b/src/lib/dragon/builder-history.ts
@@ -1,3 +1,0 @@
-import { writable } from 'svelte/store';
-
-export const dragonBuilderHistory = writable<string[]>([]);

--- a/src/lib/dragon/builder-states/BuilderDebug.svelte
+++ b/src/lib/dragon/builder-states/BuilderDebug.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-	import type { DragonConfig } from '..';
-	export let currentDragonConfig: DragonConfig | undefined;
+	import { currentDragonConfig } from '.';
 </script>
 
 <p>We're in the DEBUG state!</p>
-<p>currentDragonConfig = {JSON.stringify(currentDragonConfig)}</p>
+<p>currentDragonConfig = {JSON.stringify($currentDragonConfig)}</p>
 <p>
 	For testing with lots of content: Lorem ipsum dolor sit amet consectetur, adipisicing elit. Omnis
 	recusandae corporis dolores veniam ipsam nostrum consequuntur, soluta magnam doloremque quisquam

--- a/src/lib/dragon/builder-states/BuilderDisplay.svelte
+++ b/src/lib/dragon/builder-states/BuilderDisplay.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import type { DragonConfig } from '..';
-	export let currentDragonConfig: DragonConfig | undefined = undefined;
+	import { currentDragonConfig } from '.';
 </script>
 
 <p>
 	Eventually this will be the dragon stat block. For now, we're just displaying the
-	currentDragonConfig: {JSON.stringify(currentDragonConfig)}
+	currentDragonConfig: {JSON.stringify($currentDragonConfig)}
 </p>
 
 <p>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -18,7 +18,6 @@
 		}
 	});
 	function updateDragon() {
-		editedConfig.cleanup();
 		dispatchDragonConfig(editedConfig);
 	}
 </script>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -3,8 +3,7 @@
 	import { onMount } from 'svelte';
 
 	import { DragonConfig, COLORS, COLORS_UPPER, AGES, AGES_UPPER } from '..';
-
-	export let currentDragonConfig: DragonConfig | undefined = undefined;
+	import { currentDragonConfig } from '.';
 
 	const dispatch = createEventDispatcher<{ newDragonConfig: DragonConfig; resetDragon: null }>();
 
@@ -14,8 +13,8 @@
 
 	let editedConfig: DragonConfig = new DragonConfig();
 	onMount(() => {
-		if (currentDragonConfig !== undefined) {
-			editedConfig = currentDragonConfig;
+		if ($currentDragonConfig !== undefined) {
+			editedConfig = $currentDragonConfig;
 		}
 	});
 	function updateDragon() {
@@ -84,6 +83,6 @@
 	</div>
 
 	<button class="daisy-btn daisy-btn-neutral m-2 mt-6" on:click={updateDragon}>
-		{currentDragonConfig === undefined ? 'Build' : 'Update'} Dragon
+		{$currentDragonConfig === undefined ? 'Build' : 'Update'} Dragon
 	</button>
 </div>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -1,15 +1,8 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
 	import { onMount } from 'svelte';
 
-	import { DragonConfig, COLORS, COLORS_UPPER, AGES, AGES_UPPER } from '..';
 	import { currentDragonConfig } from '.';
-
-	const dispatch = createEventDispatcher<{ newDragonConfig: DragonConfig; resetDragon: null }>();
-
-	function dispatchDragonConfig(newDragonConfig: DragonConfig) {
-		dispatch('newDragonConfig', newDragonConfig);
-	}
+	import { DragonConfig, COLORS, COLORS_UPPER, AGES, AGES_UPPER } from '..';
 
 	let editedConfig: DragonConfig = new DragonConfig();
 	onMount(() => {
@@ -17,9 +10,6 @@
 			editedConfig = $currentDragonConfig;
 		}
 	});
-	function updateDragon() {
-		dispatchDragonConfig(editedConfig);
-	}
 </script>
 
 <div class="flex flex-col items-center">
@@ -81,7 +71,12 @@
 		/>
 	</div>
 
-	<button class="daisy-btn daisy-btn-neutral m-2 mt-6" on:click={updateDragon}>
+	<button
+		class="daisy-btn daisy-btn-neutral m-2 mt-6"
+		on:click={() => {
+			$currentDragonConfig = editedConfig;
+		}}
+	>
 		{$currentDragonConfig === undefined ? 'Build' : 'Update'} Dragon
 	</button>
 </div>

--- a/src/lib/dragon/builder-states/BuilderHistory.svelte
+++ b/src/lib/dragon/builder-states/BuilderHistory.svelte
@@ -3,7 +3,7 @@
 	import DragonConfigPreview from '../DragonConfigPreview.svelte';
 </script>
 
-<div>
+<div class="flex flex-col items-center">
 	{#each $dragonBuilderHistory as config}
 		<DragonConfigPreview {config} />
 	{/each}

--- a/src/lib/dragon/builder-states/BuilderHistory.svelte
+++ b/src/lib/dragon/builder-states/BuilderHistory.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	import { dragonBuilderHistory } from '.';
+	import DragonConfigPreview from '../DragonConfigPreview.svelte';
+</script>
+
+<div>
+	{#each $dragonBuilderHistory as config}
+		<DragonConfigPreview {config} />
+	{/each}
+</div>

--- a/src/lib/dragon/builder-states/BuilderHistory.svelte
+++ b/src/lib/dragon/builder-states/BuilderHistory.svelte
@@ -1,10 +1,51 @@
 <script lang="ts">
-	import { dragonBuilderHistory } from '.';
+	import { currentDragonConfig, dragonBuilderHistory } from '.';
+	import type { DragonConfig } from '..';
 	import DragonConfigPreview from '../DragonConfigPreview.svelte';
+
+	function onClickDelete(event: { detail: DragonConfig }) {
+		dragonBuilderHistory.remove(event.detail);
+		if ($dragonBuilderHistory.length === 0) {
+			$currentDragonConfig = undefined;
+		}
+	}
 </script>
 
+<p class="font-bold text-xl">Builder History</p>
+
 <div class="flex flex-col items-center">
-	{#each $dragonBuilderHistory as config}
-		<DragonConfigPreview {config} />
-	{/each}
+	{#if $dragonBuilderHistory.length > 0}
+		<button
+			class="daisy-btn daisy-btn-neutral m-2"
+			on:click={() => {
+				$currentDragonConfig = undefined;
+			}}
+		>
+			Return to Builder Welcome
+		</button>
+		{#each $dragonBuilderHistory as config}
+			<DragonConfigPreview {config} on:clickDelete={onClickDelete} />
+		{/each}
+		<button
+			class="daisy-btn daisy-btn-outline hover:daisy-btn-error m-2"
+			on:click={() => {
+				dragonBuilderHistory.clear();
+				$currentDragonConfig = undefined;
+			}}
+		>
+			Clear History
+		</button>
+	{:else}
+		<div>
+			<p>The Builder History is empty.</p>
+			<button
+				class="daisy-btn daisy-btn-neutral m-2"
+				on:click={() => {
+					$currentDragonConfig = undefined;
+				}}
+			>
+				Return to Builder Welcome
+			</button>
+		</div>
+	{/if}
 </div>

--- a/src/lib/dragon/builder-states/BuilderWelcome.svelte
+++ b/src/lib/dragon/builder-states/BuilderWelcome.svelte
@@ -1,22 +1,12 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 
+	import { currentDragonConfig } from '.';
 	import { DragonConfig, AGES, AGES_UPPER, COLORS, COLORS_UPPER } from '..';
 
-	const dispatch = createEventDispatcher<{
-		newDragonConfig: DragonConfig;
-		click: { buttonText: string };
-	}>();
-
-	function dispatchDragonConfig(newDragonConfig: DragonConfig) {
-		dispatch('newDragonConfig', newDragonConfig);
-	}
+	const dispatch = createEventDispatcher<{ click: { buttonText: string } }>();
 
 	let newConfig: DragonConfig = new DragonConfig();
-
-	function buildDragon() {
-		dispatchDragonConfig(newConfig);
-	}
 </script>
 
 <p class="font-bold text-xl">Welcome to the Prismatic Dragon Builder!</p>
@@ -52,7 +42,12 @@
 		</select>
 	</div>
 
-	<button class="daisy-btn daisy-btn-neutral m-2 mt-6" on:click={buildDragon}>
+	<button
+		class="daisy-btn daisy-btn-neutral m-2 mt-6"
+		on:click={() => {
+			$currentDragonConfig = newConfig;
+		}}
+	>
 		Build Dragon
 	</button>
 

--- a/src/lib/dragon/builder-states/BuilderWelcome.svelte
+++ b/src/lib/dragon/builder-states/BuilderWelcome.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 
-	import { currentDragonConfig } from '.';
+	import { currentDragonConfig, dragonBuilderHistory } from '.';
 	import { DragonConfig, AGES, AGES_UPPER, COLORS, COLORS_UPPER } from '..';
 
 	const dispatch = createEventDispatcher<{ click: { buttonText: string } }>();
@@ -61,4 +61,26 @@
 	>
 		Advanced Options
 	</button>
+
+	{#if $dragonBuilderHistory.length > 0}
+		<p class="font-bold text-lg mt-6">Build from History</p>
+		<button
+			class="daisy-btn daisy-btn-neutral m-2"
+			on:click={() => {
+				$currentDragonConfig = $dragonBuilderHistory[0];
+			}}
+		>
+			Rebuild Last Dragon
+		</button>
+		<button
+			class="daisy-btn daisy-btn-outline m-2"
+			on:click={() => {
+				dispatch('click', {
+					buttonText: 'HISTORY'
+				});
+			}}
+		>
+			View Builder History
+		</button>
+	{/if}
 </div>

--- a/src/lib/dragon/builder-states/index.ts
+++ b/src/lib/dragon/builder-states/index.ts
@@ -1,7 +1,12 @@
 import { writable, type Writable, derived, get } from 'svelte/store';
+import type { FadeParams } from 'svelte/transition';
 import { goto } from '$app/navigation';
 import { localStorageStore } from '@skeletonlabs/skeleton';
 import { DragonConfig } from '..';
+
+export const builderFadeParams: FadeParams = {
+	duration: 200
+};
 
 export const BUILDER_STATES = [
 	'LOADING',

--- a/src/lib/dragon/builder-states/index.ts
+++ b/src/lib/dragon/builder-states/index.ts
@@ -2,7 +2,14 @@ import { writable, type Writable, derived, get } from 'svelte/store';
 import { localStorageStore } from '@skeletonlabs/skeleton';
 import { DragonConfig } from '..';
 
-export const BUILDER_STATES = ['LOADING', 'WELCOME', 'DISPLAY', 'EDIT', 'DEBUG'] as const;
+export const BUILDER_STATES = [
+	'LOADING',
+	'WELCOME',
+	'DISPLAY',
+	'EDIT',
+	'HISTORY',
+	'DEBUG'
+] as const;
 export type BuilderState = (typeof BUILDER_STATES)[number];
 
 /**

--- a/src/lib/dragon/builder-states/index.ts
+++ b/src/lib/dragon/builder-states/index.ts
@@ -1,3 +1,6 @@
+import { writable } from 'svelte/store';
+import type { DragonConfig } from '..';
+
 export const BUILDER_STATES = ['LOADING', 'WELCOME', 'DISPLAY', 'EDIT', 'DEBUG'] as const;
 export type BuilderState = (typeof BUILDER_STATES)[number];
 
@@ -10,3 +13,21 @@ export type BuilderState = (typeof BUILDER_STATES)[number];
 export function stringToBuilderState(state_string: string): BuilderState | undefined {
 	return BUILDER_STATES.find((state) => state === state_string);
 }
+
+export const dragonBuilderHistory = writable<string[]>([]);
+
+function createDragonConfigStore(initialValue: DragonConfig | undefined = undefined) {
+	const { subscribe, set } = writable<DragonConfig | undefined>(initialValue);
+
+	return {
+		subscribe,
+		set: (value: DragonConfig | undefined) => {
+			if (value !== undefined) {
+				value.cleanup();
+			}
+			return set(value);
+		}
+	};
+}
+
+export const currentDragonConfig = createDragonConfigStore();

--- a/src/lib/dragon/builder-states/index.ts
+++ b/src/lib/dragon/builder-states/index.ts
@@ -71,6 +71,21 @@ export const dragonBuilderHistory = (() => {
 				_dragonBuilderHistoryAsString.set(JSON.stringify(history));
 			}
 		},
+		remove: (config: DragonConfig) => {
+			config.cleanup();
+			const configAsString = config.toString();
+			const history = get(_dragonBuilderHistoryStrings);
+			const valueIndexInHistory = history.findIndex((string: string) => {
+				return string === configAsString;
+			});
+			if (valueIndexInHistory >= 0) {
+				history.splice(valueIndexInHistory, 1);
+				_dragonBuilderHistoryAsString.set(JSON.stringify(history));
+			}
+		},
+		clear: () => {
+			_dragonBuilderHistoryAsString.set('[]');
+		},
 		toStrings: () => {
 			return get(_dragonBuilderHistoryStrings);
 		}

--- a/src/lib/dragon/builder-states/index.ts
+++ b/src/lib/dragon/builder-states/index.ts
@@ -79,6 +79,7 @@ export const currentDragonConfig = (() => {
 		set: (value: DragonConfig | undefined) => {
 			if (value !== undefined) {
 				value.cleanup();
+				dragonBuilderHistory.add(value);
 			}
 			set(value);
 		}

--- a/src/lib/dragon/builder-states/index.ts
+++ b/src/lib/dragon/builder-states/index.ts
@@ -46,8 +46,8 @@ export const dragonBuilderHistory = (() => {
 	};
 })();
 
-function createDragonConfigStore(initialValue: DragonConfig | undefined = undefined) {
-	const { subscribe, set } = writable<DragonConfig | undefined>(initialValue);
+export const currentDragonConfig = (() => {
+	const { subscribe, set } = writable<DragonConfig | undefined>(undefined);
 
 	return {
 		subscribe,
@@ -58,6 +58,4 @@ function createDragonConfigStore(initialValue: DragonConfig | undefined = undefi
 			set(value);
 		}
 	};
-}
-
-export const currentDragonConfig = createDragonConfigStore();
+})();

--- a/src/lib/dragon/index.test.ts
+++ b/src/lib/dragon/index.test.ts
@@ -87,3 +87,32 @@ test('DragonConfig.fromURLSearchParams() behavior', () => {
 	params1.append('color', 'Jeremy'); // invalid color, appended after valid color
 	expect(dragonConfig.fromURLSearchParams(params1)).toBe(true);
 });
+
+test('DragonConfig.fromString() behavior', () => {
+	const dragonConfig = new DragonConfig();
+
+	// empty string is not valid
+	let testString = '';
+	expect(dragonConfig.fromString(testString)).toBe(false);
+	expect(dragonConfig.fromString(`?${testString}`)).toBe(false);
+
+	// valid age, invalid color
+	testString = 'age=young&color=Jeremy';
+	expect(dragonConfig.fromString(testString)).toBe(false);
+	expect(dragonConfig.fromString(`?${testString}`)).toBe(false);
+
+	// valid color after invalid color
+	testString = 'age=young&color=Jeremy&color=blue';
+	expect(dragonConfig.fromString(testString)).toBe(false);
+	expect(dragonConfig.fromString(`?${testString}`)).toBe(false);
+
+	// valid age and color
+	testString = 'age=young&color=blue';
+	expect(dragonConfig.fromString(testString)).toBe(true);
+	expect(dragonConfig.fromString(`?${testString}`)).toBe(true);
+
+	// invalid color after valid color
+	testString = 'age=young&color=blue&color=Jeremy';
+	expect(dragonConfig.fromString(testString)).toBe(true);
+	expect(dragonConfig.fromString(`?${testString}`)).toBe(true);
+});

--- a/src/lib/dragon/index.test.ts
+++ b/src/lib/dragon/index.test.ts
@@ -77,42 +77,87 @@ test('DragonConfig.fromURLSearchParams() behavior', () => {
 	params1.set('age', 'young'); // valid age
 	params1.set('color', 'Jeremy'); // invalid color
 	expect(dragonConfig.fromURLSearchParams(params1)).toBe(false);
+	let testStringOutput = dragonConfig.toString();
+	let expectedStringOutput = 'age=wyrmling&color=red';
+	expect(testStringOutput).toBe(expectedStringOutput);
 
 	params1.append('color', 'blue'); // valid color, appended after invalid color
 	expect(dragonConfig.fromURLSearchParams(params1)).toBe(false);
+	testStringOutput = dragonConfig.toString();
+	expectedStringOutput = 'age=wyrmling&color=red';
+	expect(testStringOutput).toBe(expectedStringOutput);
 
 	params1.set('color', 'blue'); // valid color, replacing all other color values
 	expect(dragonConfig.fromURLSearchParams(params1)).toBe(true);
+	testStringOutput = dragonConfig.toString();
+	expectedStringOutput = 'age=young&color=blue';
+	expect(testStringOutput).toBe(expectedStringOutput);
 
 	params1.append('color', 'Jeremy'); // invalid color, appended after valid color
 	expect(dragonConfig.fromURLSearchParams(params1)).toBe(true);
+	testStringOutput = dragonConfig.toString();
+	expectedStringOutput = 'age=young&color=blue';
+	expect(testStringOutput).toBe(expectedStringOutput);
+
+	const params2 = new URLSearchParams();
+	// valid age and color, but in opposite order, which doesn't matter
+	params2.set('color', 'indigo');
+	params2.set('age', 'adult');
+	expect(dragonConfig.fromURLSearchParams(params2)).toBe(true);
+	testStringOutput = dragonConfig.toString();
+	expectedStringOutput = 'age=adult&color=indigo';
+	expect(testStringOutput).toBe(expectedStringOutput);
 });
 
 test('DragonConfig.fromString() behavior', () => {
 	const dragonConfig = new DragonConfig();
 
 	// empty string is not valid
-	let testString = '';
-	expect(dragonConfig.fromString(testString)).toBe(false);
-	expect(dragonConfig.fromString(`?${testString}`)).toBe(false);
+	let testStringInput = '';
+	expect(dragonConfig.fromString(testStringInput)).toBe(false);
+	// results are unchanged by adding a '?' at the start of the string
+	expect(dragonConfig.fromString(`?${testStringInput}`)).toBe(false);
+	let testStringOutput = dragonConfig.toString();
+	let expectedStringOutput = 'age=wyrmling&color=red';
+	expect(testStringOutput).toBe(expectedStringOutput);
 
 	// valid age, invalid color
-	testString = 'age=young&color=Jeremy';
-	expect(dragonConfig.fromString(testString)).toBe(false);
-	expect(dragonConfig.fromString(`?${testString}`)).toBe(false);
+	testStringInput = 'age=young&color=Jeremy';
+	expect(dragonConfig.fromString(testStringInput)).toBe(false);
+	expect(dragonConfig.fromString(`?${testStringInput}`)).toBe(false);
+	testStringOutput = dragonConfig.toString();
+	expectedStringOutput = 'age=wyrmling&color=red';
+	expect(testStringOutput).toBe(expectedStringOutput);
 
 	// valid color after invalid color
-	testString = 'age=young&color=Jeremy&color=blue';
-	expect(dragonConfig.fromString(testString)).toBe(false);
-	expect(dragonConfig.fromString(`?${testString}`)).toBe(false);
+	testStringInput = 'age=young&color=Jeremy&color=blue';
+	expect(dragonConfig.fromString(testStringInput)).toBe(false);
+	expect(dragonConfig.fromString(`?${testStringInput}`)).toBe(false);
+	testStringOutput = dragonConfig.toString();
+	expectedStringOutput = 'age=wyrmling&color=red';
+	expect(testStringOutput).toBe(expectedStringOutput);
 
 	// valid age and color
-	testString = 'age=young&color=blue';
-	expect(dragonConfig.fromString(testString)).toBe(true);
-	expect(dragonConfig.fromString(`?${testString}`)).toBe(true);
+	testStringInput = 'age=young&color=blue';
+	expect(dragonConfig.fromString(testStringInput)).toBe(true);
+	expect(dragonConfig.fromString(`?${testStringInput}`)).toBe(true);
+	testStringOutput = dragonConfig.toString();
+	expectedStringOutput = testStringInput; // input and output should be equal
+	expect(testStringOutput).toBe(expectedStringOutput);
 
 	// invalid color after valid color
-	testString = 'age=young&color=blue&color=Jeremy';
-	expect(dragonConfig.fromString(testString)).toBe(true);
-	expect(dragonConfig.fromString(`?${testString}`)).toBe(true);
+	testStringInput = 'age=young&color=blue&color=Jeremy';
+	expect(dragonConfig.fromString(testStringInput)).toBe(true);
+	expect(dragonConfig.fromString(`?${testStringInput}`)).toBe(true);
+	testStringOutput = dragonConfig.toString();
+	expectedStringOutput = 'age=young&color=blue'; // Jeremy is gone!
+	expect(testStringOutput).toBe(expectedStringOutput);
+
+	// swap the order of age and color, still valid
+	testStringInput = 'color=indigo&age=adult';
+	expect(dragonConfig.fromString(testStringInput)).toBe(true);
+	expect(dragonConfig.fromString(`?${testStringInput}`)).toBe(true);
+	testStringOutput = dragonConfig.toString();
+	expectedStringOutput = 'age=adult&color=indigo'; // back in the normal order
+	expect(testStringOutput).toBe(expectedStringOutput);
 });

--- a/src/lib/dragon/index.test.ts
+++ b/src/lib/dragon/index.test.ts
@@ -7,6 +7,9 @@ import {
 	COLORS,
 	COLORS_UPPER,
 	stringToColor,
+	type RGB,
+	COLOR_TO_THEME,
+	RGBToRGBA,
 	DragonConfig
 } from '.';
 
@@ -47,6 +50,45 @@ test('stringToColor() behavior', () => {
 
 	for (const color of COLORS) {
 		expect(stringToColor(color)).toBe(color);
+	}
+});
+
+test('RGBToRGBA() behavior', () => {
+	const rgb: RGB = `rgb(${0}, ${0}, ${0})`;
+	expect(RGBToRGBA(rgb, 0.5)).toBe(`rgba(${0}, ${0}, ${0}, ${0.5})`);
+});
+
+test('DragonConfig.getTitle() behavior', () => {
+	const dragonConfig = new DragonConfig();
+
+	// default behavior
+	expect(dragonConfig.getTitle()).toBe('Red Dragon Wyrmling');
+
+	// other ages have a different format
+	for (let i = 1; i < AGES.length; i++) {
+		dragonConfig.age = AGES[i];
+		expect(dragonConfig.getTitle()).toBe(`${AGES_UPPER[i]} Red Dragon`);
+	}
+
+	// adding a name puts the default title in parentheses
+	dragonConfig.age = 'wyrmling'; // reset
+	dragonConfig.name = 'Amara';
+	expect(dragonConfig.getTitle()).toBe('Amara (Red Dragon Wyrmling)');
+
+	// it will ignore the name if it's the empty string though
+	dragonConfig.name = '';
+	expect(dragonConfig.getTitle()).toBe('Red Dragon Wyrmling');
+});
+
+test('DragonConfig.getTheme() behavior', () => {
+	const dragonConfig = new DragonConfig();
+
+	// default behavior
+	expect(dragonConfig.getTheme()).toBe(COLOR_TO_THEME['red']);
+
+	for (const color of COLORS) {
+		dragonConfig.color = color;
+		expect(dragonConfig.getTheme()).toBe(COLOR_TO_THEME[color]);
 	}
 });
 

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Returns the given string with its first character capitalized.
+ * @export
+ * @param {string} string
+ * @return {*}  {string}
+ */
 export function capitalizeFirstLetter(string: string): string {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 }

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -10,11 +10,11 @@ export type Age = (typeof AGES)[number];
 /**
  * Converts input string to Age if possible, returning undefined if not.
  * @export
- * @param {string} age_string
+ * @param {string} ageString
  * @return {*}  {(Age | undefined)}
  */
-export function stringToAge(age_string: string): Age | undefined {
-	return AGES.find((age) => age === age_string);
+export function stringToAge(ageString: string): Age | undefined {
+	return AGES.find((age) => age === ageString);
 }
 
 export const COLORS = ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'] as const;
@@ -25,11 +25,11 @@ export type Color = (typeof COLORS)[number];
 /**
  * Converts input string to Color if possible, returning undefined if not.
  * @export
- * @param {string} color_string
+ * @param {string} colorString
  * @return {*}  {(Color | undefined)}
  */
-export function stringToColor(color_string: string): Color | undefined {
-	return COLORS.find((color) => color === color_string);
+export function stringToColor(colorString: string): Color | undefined {
+	return COLORS.find((color) => color === colorString);
 }
 
 export type RGB = `rgb(${number}, ${number}, ${number})`;
@@ -127,5 +127,16 @@ export class DragonConfig {
 		}
 
 		return true;
+	}
+
+	/**
+	 * If given string has valid DragonConfig values, sets this DragonConfig from them and returns true.
+	 * @param {string} paramsString
+	 * @return {*}  {boolean} If given string has valid DragonConfig values, true. Otherwise false.
+	 * @memberof DragonConfig
+	 */
+	fromString(paramsString: string): boolean {
+		const params = new URLSearchParams(paramsString);
+		return this.fromURLSearchParams(params);
 	}
 }

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -51,11 +51,57 @@ export const COLOR_TO_THEME: {
 	violet: 'rgb(118, 43, 158)'
 } as const;
 
+/**
+ * Returns an RGBA string with the given RGB and A value.
+ * @export
+ * @param {RGB} rgb
+ * @param {number} a
+ * @return {*}  {string}
+ */
+export function RGBToRGBA(rgb: RGB, a: number): string {
+	return `rgba(${rgb.substring(4, rgb.length - 1)}, ${a})`;
+}
+
 export class DragonConfig {
 	age: Age = 'wyrmling';
 	color: Color = 'red';
 	name?: string;
 	alignment?: string;
+
+	/**
+	 * Returns the title for this DragonConfig.
+	 * @return {*}  {string}
+	 * @memberof DragonConfig
+	 */
+	getTitle(): string {
+		let output = '';
+
+		let descriptiveTitle = '';
+		const capitalizedAge = capitalizeFirstLetter(this.age);
+		const capitalizedColor = capitalizeFirstLetter(this.color);
+		if (this.age === 'wyrmling') {
+			descriptiveTitle = `${capitalizedColor} Dragon ${capitalizedAge}`;
+		} else {
+			descriptiveTitle = `${capitalizedAge} ${capitalizedColor} Dragon`;
+		}
+
+		if (this.name === undefined || this.name === '') {
+			output = descriptiveTitle;
+		} else {
+			output = `${this.name} (${descriptiveTitle})`;
+		}
+
+		return output;
+	}
+
+	/**
+	 * Returns the RGB theme for this DragonConfig.
+	 * @return {*}  {RGB}
+	 * @memberof DragonConfig
+	 */
+	getTheme(): RGB {
+		return COLOR_TO_THEME[this.color];
+	}
 
 	/**
 	 * Deletes unneeded members of this DragonConfig.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,7 @@ const config = {
 			{
 				statBlockContents: {
 					...require('daisyui/src/theming/themes')['[data-theme=light]'],
+					primary: '#0fba81',
 					'base-100': '#eee',
 					'--btn-text-case': 'none'
 				}


### PR DESCRIPTION
## What's in this PR?
This PR adds in a key Dragon Builder feature: a History, persisting by using the `localStorageStore` from Skeleton UI. The Builder History is visible as its own state within the Dragon Builder. When the History isn't empty, it can be accessed from the Welcome state.

The `currentDragonConfig` is now a store that can be accessed from anywhere, simplifying the process of updating it. When it gets updated, the URL is immediately updated to match the new config. The `currentDragonConfig` no longer gets set twice whenever it's set. Instead, setting the `currentDragonConfig` triggers the URL update, and the `currentDragonConfig` is only actually updated when it's getting set from a URL. This is a somewhat confusing behavior, but it seemed like the best option.

There are myriad small improvements:
- The header buttons now have a more contrasting color on hover.
- The fade duration for Builder transitions is now an export, so its value can be used to set the duration of the `DragonContainer` height transition.
- `DragonConfig` now has a few new useful methods which have documentation and tests: `getTitle`, `getTheme`, and `fromString`.
- Some missing function documentation and tests were added. Some names were standardized.
- Added a new utility function for adding opacity to an RGB string: `RGBToRGBA`.
- Cleaned up the `DragonControlButtons`.
- The daisyUI `statBlockContents` now has the same primary color as the rest of the site.

## 🐢
