### PR TITLE
Updating URL to petalquest.com + routing updates

### DIFF
--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 
-	import { currentDragonConfig } from '.';
+	import { currentDragonConfig, lastBuilderState, nextBuilderState } from '.';
 	import { DragonConfig, COLORS, COLORS_UPPER, AGES, AGES_UPPER } from '..';
 
 	let editedConfig: DragonConfig = new DragonConfig();
 	onMount(() => {
 		if ($currentDragonConfig !== undefined) {
-			editedConfig = $currentDragonConfig;
+			editedConfig = DragonConfig.newFromDragonConfig($currentDragonConfig);
 		}
 	});
 </script>
@@ -74,7 +74,19 @@
 	<button
 		class="daisy-btn daisy-btn-neutral m-2 mt-6"
 		on:click={() => {
-			$currentDragonConfig = editedConfig;
+			editedConfig.cleanup();
+			if (
+				$currentDragonConfig !== undefined &&
+				$currentDragonConfig.toString() === editedConfig.toString() &&
+				$lastBuilderState !== undefined &&
+				$lastBuilderState !== 'LOADING' &&
+				$lastBuilderState !== 'EDIT'
+			) {
+				// no change is being made, so let's just return to the last state
+				$nextBuilderState = $lastBuilderState;
+			} else {
+				$currentDragonConfig = editedConfig;
+			}
 		}}
 	>
 		{$currentDragonConfig === undefined ? 'Build' : 'Update'} Dragon

--- a/src/lib/dragon/index.test.ts
+++ b/src/lib/dragon/index.test.ts
@@ -97,6 +97,9 @@ test('DragonConfig.toString() behavior', () => {
 	const defaultString = 'age=wyrmling&color=red';
 	expect(dragonConfig.toString()).toBe(defaultString);
 
+	// toString is called when a DragonConfig is put into a string like so
+	expect(`${dragonConfig}`).toBe(defaultString);
+
 	const testName = 'Amara';
 	const testAlignment = 'Chaotic';
 	dragonConfig.name = testName;
@@ -202,4 +205,16 @@ test('DragonConfig.fromString() behavior', () => {
 	testStringOutput = dragonConfig.toString();
 	expectedStringOutput = 'age=adult&color=indigo'; // back in the normal order
 	expect(testStringOutput).toBe(expectedStringOutput);
+});
+
+test('DragonConfig.newFromDragonConfig() behavior', () => {
+	const dragonConfig1 = new DragonConfig();
+	dragonConfig1.name = 'Amara'; // making sure at least one value isn't default
+	const dragonConfig2 = dragonConfig1;
+	expect(dragonConfig2).toBe(dragonConfig1);
+	expect(dragonConfig2.toString()).toBe(dragonConfig1.toString());
+
+	const dragonConfig3 = DragonConfig.newFromDragonConfig(dragonConfig1);
+	expect(dragonConfig3).not.toBe(dragonConfig1);
+	expect(dragonConfig3.toString()).toBe(dragonConfig1.toString());
 });

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -191,4 +191,17 @@ export class DragonConfig {
 		const params = new URLSearchParams(paramsString);
 		return this.fromURLSearchParams(params);
 	}
+
+	/**
+	 * Returns a new DragonConfig with the same params as the given one.
+	 * @static
+	 * @param {DragonConfig} configIn
+	 * @return {*}  {DragonConfig}
+	 * @memberof DragonConfig
+	 */
+	static newFromDragonConfig(configIn: DragonConfig): DragonConfig {
+		const config = new DragonConfig();
+		config.fromURLSearchParams(configIn.toURLSearchParams());
+		return config;
+	}
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,4 +7,4 @@ export const NAV_LINKS: readonly {
 	{ href: '/about', text: 'About' }
 ] as const;
 
-export const BASE_SHARE_URL = 'petal.palladiumturtle.com/dragon';
+export const BASE_SHARE_URL = 'https://dragon.petal.quest/';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,3 +6,5 @@ export const NAV_LINKS: readonly {
 	{ href: '/dragon-builder', text: 'Dragon Builder' },
 	{ href: '/about', text: 'About' }
 ] as const;
+
+export const BASE_SHARE_URL = 'petal.palladiumturtle.com/dragon';

--- a/src/lib/modals/DragonShare.svelte
+++ b/src/lib/modals/DragonShare.svelte
@@ -7,11 +7,12 @@
 	import { getModalStore, clipboard } from '@skeletonlabs/skeleton';
 	const modalStore = getModalStore();
 
-	import { page } from '$app/stores';
+	import { BASE_SHARE_URL } from '$lib';
 
-	const baseShareURL = `${$page.url.origin}/dragon-builder`;
 	let shareURL =
-		$modalStore[0].value === undefined ? baseShareURL : `${baseShareURL}?${$modalStore[0].value}`;
+		$modalStore[0].value === undefined
+			? BASE_SHARE_URL
+			: `${BASE_SHARE_URL}?${$modalStore[0].value}`;
 </script>
 
 {#if $modalStore[0]}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,7 +26,7 @@
 		<Header />
 	</svelte:fragment>
 	<main class="text-center">
-		<div class="p-4 px-2 mx-auto my-0 w-auto max-w-5xl">
+		<div class="p-2 pb-4 mx-auto my-0 w-auto max-w-5xl">
 			<slot />
 		</div>
 	</main>

--- a/src/routes/dragon/+page.svelte
+++ b/src/routes/dragon/+page.svelte
@@ -1,0 +1,10 @@
+<script>
+	import { page } from '$app/stores';
+	import { onMount } from 'svelte';
+
+	onMount(() => {
+		const redirectURL = `/dragon-builder${$page.url.search}`;
+		window.history.replaceState(history.state, '', redirectURL);
+		location.reload();
+	});
+</script>

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-petal.palladiumturtle.com
+www.petalquest.com


### PR DESCRIPTION
## What's in this PR?
This PR mainly updates the CNAME record (and BASE_SHARE_URL) to use the new domains I just purchased. I also did the following:
- The `/dragon` route now redirects to `/dragon-builder`
- Clicking "Update Dragon" without any changes made no longer adds an entry to history
- I decreased the top padding of the app slightly.
- I added a new static function `DragonConfig.newFromDragonConfig` which lets you make a new dragon config from an existing one. This is helpful for doing a one-line object update which will cause the bound DOM elements to actually update.

## 🐢
