### PR TITLE
DragonBuilder Edit + Meta improvements

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -13,6 +13,8 @@
 			crossorigin
 		/>
 
+		<meta property="og:site_name" content="Petal Quest" />
+
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover" data-theme="my-custom-theme">

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -118,4 +118,8 @@ body {
 	.breath-option p {
 		@apply indent-4;
 	}
+
+	.daisy-select {
+		@apply font-normal;
+	}
 }

--- a/src/lib/PageMeta.svelte
+++ b/src/lib/PageMeta.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	export let title: string;
+	export let type: string = 'website';
+	export let description: string;
+	export let url: string;
+	// export let image: string = 'preview.png';
+</script>
+
+<svelte:head>
+	<title>{title}</title>
+	<meta property="og:title" content={title} />
+
+	<meta property="og:type" content={type} />
+
+	<meta name="description" content={description} />
+	<meta property="og:description" content={description} />
+
+	<meta property="og:url" content={url} />
+
+	<!-- <meta property="og:image" content="%sveltekit.assets%/{image}" /> -->
+</svelte:head>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -4,6 +4,7 @@
 	import { currentDragonConfig, nextBuilderState } from '.';
 	import { DEFAULT_PRONOUNS, DragonConfig } from '..';
 	import FormSectionBasics from './edit-form/FormSectionBasics.svelte';
+	import FormSectionHpAbilities from './edit-form/FormSectionHPAbilities.svelte';
 	import FormSectionSkills from './edit-form/FormSectionSkills.svelte';
 	import FormSectionSpells from './edit-form/FormSectionSpells.svelte';
 	import { getToastStore, type ToastSettings } from '@skeletonlabs/skeleton';
@@ -51,10 +52,11 @@
 		toastStore.trigger(t);
 	}
 
-	const FORM_SECTION_NAMES = ['Basics', 'Skills', 'Spells'] as const;
+	const FORM_SECTION_NAMES = ['Basics', 'HP & Abilities', 'Skills', 'Spells'] as const;
 	type FormSectionName = (typeof FORM_SECTION_NAMES)[number];
 	const formSections = {
 		Basics: FormSectionBasics,
+		'HP & Abilities': FormSectionHpAbilities,
 		Skills: FormSectionSkills,
 		Spells: FormSectionSpells
 	} as const;
@@ -90,7 +92,9 @@
 		style="--outer-wrapper-height: {outerWrapperHeight}px; transition: height {heightTransitionDuration}ms ease;"
 	>
 		<div class="inner-wrapper w-full" bind:clientHeight={innerClientHeight}>
-			<svelte:component this={formSections[currentSectionName]} config={editedConfig} />
+			<div class="flex flex-col items-center w-full">
+				<svelte:component this={formSections[currentSectionName]} config={editedConfig} />
+			</div>
 		</div>
 	</div>
 

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -25,7 +25,7 @@
 </script>
 
 <div class="flex flex-col items-center">
-	<div class="daisy-tabs daisy-tabs-boxed font-semibold border border-black gap-1 mb-3">
+	<div class="daisy-tabs daisy-tabs-boxed font-semibold border border-black gap-1">
 		{#each FORM_SECTION_NAMES as name}
 			<button
 				class="daisy-tab"
@@ -40,10 +40,14 @@
 		{/each}
 	</div>
 
+	<div class="daisy-divider my-2" />
+
 	<svelte:component this={formSections[currentSectionName]} config={editedConfig} />
 
+	<div class="daisy-divider my-2" />
+
 	<button
-		class="daisy-btn daisy-btn-neutral m-2 mt-6"
+		class="daisy-btn daisy-btn-neutral"
 		on:click={() => {
 			editedConfig.cleanup();
 			if (

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -25,6 +25,12 @@
 		Spells: FormSectionSpells
 	} as const;
 	let currentSectionName: FormSectionName = 'Basics';
+
+	let innerClientHeight: number;
+	let outerWrapperHeight: number;
+	$: outerWrapperHeight = innerClientHeight;
+
+	let heightTransitionDuration = 100;
 </script>
 
 <div class="flex flex-col items-center">
@@ -45,7 +51,14 @@
 
 	<div class="daisy-divider my-2" />
 
-	<svelte:component this={formSections[currentSectionName]} config={editedConfig} />
+	<div
+		class="outer-wrapper w-full"
+		style="--outer-wrapper-height: {outerWrapperHeight}px; transition: height {heightTransitionDuration}ms ease;"
+	>
+		<div class="inner-wrapper w-full" bind:clientHeight={innerClientHeight}>
+			<svelte:component this={formSections[currentSectionName]} config={editedConfig} />
+		</div>
+	</div>
 
 	<div class="daisy-divider my-2" />
 
@@ -70,3 +83,20 @@
 		{$currentDragonConfig === undefined ? 'Build' : 'Update'} Dragon
 	</button>
 </div>
+
+<style>
+	.outer-wrapper {
+		@apply overflow-hidden;
+		height: var(--outer-wrapper-height);
+	}
+
+	@media print {
+		.outer-wrapper {
+			height: fit-content;
+		}
+	}
+
+	.inner-wrapper {
+		@apply h-fit inline-block;
+	}
+</style>

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 
 	import { currentDragonConfig, lastBuilderState, nextBuilderState } from '.';
-	import { DragonConfig } from '..';
+	import { DEFAULT_PRONOUNS, DragonConfig } from '..';
 	import FormSectionBasics from './edit-form/FormSectionBasics.svelte';
 	import FormSectionSkills from './edit-form/FormSectionSkills.svelte';
 	import FormSectionSpells from './edit-form/FormSectionSpells.svelte';
@@ -11,6 +11,9 @@
 	onMount(() => {
 		if ($currentDragonConfig !== undefined) {
 			editedConfig = DragonConfig.newFromDragonConfig($currentDragonConfig);
+			if (editedConfig.pronouns === undefined) {
+				editedConfig.pronouns = DEFAULT_PRONOUNS;
+			}
 		}
 	});
 

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -25,8 +25,8 @@
 </script>
 
 <div class="flex flex-col items-center">
-	<div class="daisy-tabs daisy-tabs-boxed font-semibold border border-black gap-1">
-		{#each FORM_SECTION_NAMES as name, index}
+	<div class="daisy-tabs daisy-tabs-boxed font-semibold border border-black gap-1 mb-3">
+		{#each FORM_SECTION_NAMES as name}
 			<button
 				class="daisy-tab"
 				class:daisy-btn-ghost={currentSectionName !== name}

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -2,7 +2,8 @@
 	import { onMount } from 'svelte';
 
 	import { currentDragonConfig, lastBuilderState, nextBuilderState } from '.';
-	import { DragonConfig, COLORS, COLORS_UPPER, AGES, AGES_UPPER } from '..';
+	import { DragonConfig } from '..';
+	import FormSectionBasics from './edit-form/FormSectionBasics.svelte';
 
 	let editedConfig: DragonConfig = new DragonConfig();
 	onMount(() => {
@@ -13,63 +14,7 @@
 </script>
 
 <div class="flex flex-col items-center">
-	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="age">
-			<span class="daisy-label-text">Age</span>
-		</label>
-		<select
-			bind:value={editedConfig.age}
-			class="daisy-select daisy-select-bordered bg-white"
-			name="age"
-		>
-			{#each AGES as age, index}
-				<option value={age}>{AGES_UPPER[index]}</option>
-			{/each}
-		</select>
-	</div>
-
-	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="color">
-			<span class="daisy-label-text">Color</span>
-		</label>
-		<select
-			bind:value={editedConfig.color}
-			class="daisy-select daisy-select-bordered bg-white"
-			name="color"
-		>
-			{#each COLORS as color, index}
-				<option value={color}>{COLORS_UPPER[index]}</option>
-			{/each}
-		</select>
-	</div>
-
-	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="name">
-			<span class="daisy-label-text">Name</span>
-		</label>
-		<input
-			type="text"
-			bind:value={editedConfig.name}
-			placeholder={'Referred to as "the dragon" by default'}
-			class="daisy-input daisy-input-bordered bg-white"
-			name="name"
-			data-1p-ignore
-		/>
-	</div>
-
-	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="alignment">
-			<span class="daisy-label-text">Alignment</span>
-		</label>
-		<input
-			type="text"
-			bind:value={editedConfig.alignment}
-			placeholder="Defaults to typical alignment for this color"
-			class="daisy-input daisy-input-bordered bg-white"
-			name="alignment"
-			data-1p-ignore
-		/>
-	</div>
+	<FormSectionBasics config={editedConfig} />
 
 	<button
 		class="daisy-btn daisy-btn-neutral m-2 mt-6"

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -4,6 +4,8 @@
 	import { currentDragonConfig, lastBuilderState, nextBuilderState } from '.';
 	import { DragonConfig } from '..';
 	import FormSectionBasics from './edit-form/FormSectionBasics.svelte';
+	import FormSectionSkills from './edit-form/FormSectionSkills.svelte';
+	import FormSectionSpells from './edit-form/FormSectionSpells.svelte';
 
 	let editedConfig: DragonConfig = new DragonConfig();
 	onMount(() => {
@@ -11,10 +13,34 @@
 			editedConfig = DragonConfig.newFromDragonConfig($currentDragonConfig);
 		}
 	});
+
+	const FORM_SECTION_NAMES = ['Basics', 'Skills', 'Spells'] as const;
+	type FormSectionName = (typeof FORM_SECTION_NAMES)[number];
+	const formSections = {
+		Basics: FormSectionBasics,
+		Skills: FormSectionSkills,
+		Spells: FormSectionSpells
+	} as const;
+	let currentSectionName: FormSectionName = 'Basics';
 </script>
 
 <div class="flex flex-col items-center">
-	<FormSectionBasics config={editedConfig} />
+	<div class="daisy-tabs daisy-tabs-boxed font-semibold border border-black gap-1">
+		{#each FORM_SECTION_NAMES as name, index}
+			<button
+				class="daisy-tab"
+				class:daisy-btn-ghost={currentSectionName !== name}
+				class:daisy-btn-neutral={currentSectionName === name}
+				on:click={() => {
+					currentSectionName = name;
+				}}
+			>
+				{name}
+			</button>
+		{/each}
+	</div>
+
+	<svelte:component this={formSections[currentSectionName]} config={editedConfig} />
 
 	<button
 		class="daisy-btn daisy-btn-neutral m-2 mt-6"

--- a/src/lib/dragon/builder-states/BuilderHistory.svelte
+++ b/src/lib/dragon/builder-states/BuilderHistory.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
 	import { flip, type FlipParams } from 'svelte/animate';
 	import { fade, type FadeParams, fly, type FlyParams } from 'svelte/transition';
-	import { currentDragonConfig, dragonBuilderHistory, lastBuilderState, nextBuilderState } from '.';
+	import {
+		currentDragonConfig,
+		dragonBuilderHistory,
+		lastBuilderState,
+		nextBuilderState,
+		dragonBuilderHistoryMaxLength
+	} from '.';
 	import { type DragonConfig, capitalizeFirstLetter } from '..';
 	import DragonConfigPreview from '../DragonConfigPreview.svelte';
 	import { getToastStore, type ToastSettings } from '@skeletonlabs/skeleton';
@@ -97,17 +103,32 @@
 	}
 </script>
 
-<p class="font-bold text-xl">Builder History</p>
+<p class="font-bold text-xl mb-2">Builder History</p>
+
+<p class="m-2">
+	Dragons are saved in this browser's local storage, up to a maximum of {dragonBuilderHistoryMaxLength}
+	dragons.
+</p>
 
 <div class="flex flex-col items-center">
-	<button
-		class="daisy-btn daisy-btn-neutral m-2"
-		on:click={() => {
-			$nextBuilderState = returnState;
-		}}
-	>
-		Return to Builder {capitalizeFirstLetter(returnState.toLowerCase())}
-	</button>
+	{#if historyPagesNeeded > 1}
+		<div class="daisy-join m-2">
+			{#each Array(historyPagesNeeded) as _, index (index)}
+				<button
+					class="daisy-join-item daisy-btn daisy-btn-outline"
+					class:daisy-btn-active={index === currentHistoryPage}
+					on:click={() => {
+						setHistoryPage(index);
+					}}
+				>
+					{index + 1}
+				</button>
+			{/each}
+		</div>
+	{/if}
+
+	<div class="daisy-divider my-2" />
+
 	<div
 		class="outer-wrapper max-w-xl w-full"
 		style="--outer-wrapper-height: {outerWrapperHeight}px; transition: height {heightTransitionDuration}ms ease;"
@@ -127,24 +148,21 @@
 			</ul>
 		</div>
 	</div>
-	{#if historyPagesNeeded > 1}
-		<div class="daisy-join m-2">
-			{#each Array(historyPagesNeeded) as _, index (index)}
-				<button
-					class="daisy-join-item daisy-btn daisy-btn-outline"
-					class:daisy-btn-active={index === currentHistoryPage}
-					on:click={() => {
-						setHistoryPage(index);
-					}}
-				>
-					{index + 1}
-				</button>
-			{/each}
-		</div>
-	{/if}
+
+	<div class="daisy-divider my-2" />
+
+	<button
+		class="daisy-btn daisy-btn-neutral m-2"
+		on:click={() => {
+			$nextBuilderState = returnState;
+		}}
+	>
+		Return to Builder {capitalizeFirstLetter(returnState.toLowerCase())}
+	</button>
+
 	{#if $dragonBuilderHistory.length > 0}
 		<button
-			class="daisy-btn daisy-btn-outline hover:daisy-btn-error m-2 mt-6"
+			class="daisy-btn daisy-btn-outline hover:daisy-btn-error m-2"
 			on:click={onClickClearHistory}
 		>
 			Clear History

--- a/src/lib/dragon/builder-states/BuilderWelcome.svelte
+++ b/src/lib/dragon/builder-states/BuilderWelcome.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { nextBuilderState, currentDragonConfig, dragonBuilderHistory } from '.';
-	import { DragonConfig, AGES, AGES_UPPER, COLORS, COLORS_UPPER } from '..';
+	import { DragonConfig } from '..';
+	import FormSubsectionWelcome from './edit-form/FormSubsectionWelcome.svelte';
 
 	let newConfig: DragonConfig = new DragonConfig();
 </script>
@@ -8,35 +9,7 @@
 <p class="font-bold text-xl">Welcome to the Prismatic Dragon Builder!</p>
 
 <div class="flex flex-col items-center">
-	<div class="daisy-form-control w-full max-w-xs m-1">
-		<label class="daisy-label" for="age">
-			<span class="daisy-label-text">Age</span>
-		</label>
-		<select
-			bind:value={newConfig.age}
-			class="daisy-select daisy-select-bordered bg-white"
-			name="age"
-		>
-			{#each AGES as age, index}
-				<option value={age}>{AGES_UPPER[index]}</option>
-			{/each}
-		</select>
-	</div>
-
-	<div class="daisy-form-control w-full max-w-xs m-1">
-		<label class="daisy-label" for="color">
-			<span class="daisy-label-text">Color</span>
-		</label>
-		<select
-			bind:value={newConfig.color}
-			class="daisy-select daisy-select-bordered bg-white"
-			name="color"
-		>
-			{#each COLORS as color, index}
-				<option value={color}>{COLORS_UPPER[index]}</option>
-			{/each}
-		</select>
-	</div>
+	<FormSubsectionWelcome config={newConfig} />
 
 	<button
 		class="daisy-btn daisy-btn-neutral m-2 mt-6"

--- a/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
@@ -9,20 +9,6 @@
 	<FormSubsectionWelcome {config} />
 
 	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="name">
-			<span class="daisy-label-text">Name</span>
-		</label>
-		<input
-			type="text"
-			bind:value={config.name}
-			placeholder={'Referred to as "the dragon" by default'}
-			class="daisy-input daisy-input-bordered bg-white"
-			name="name"
-			data-1p-ignore
-		/>
-	</div>
-
-	<div class="daisy-form-control w-full max-w-sm m-1">
 		<label class="daisy-label" for="alignment">
 			<span class="daisy-label-text">Alignment</span>
 		</label>
@@ -32,7 +18,53 @@
 			placeholder="Defaults to typical alignment for this color"
 			class="daisy-input daisy-input-bordered bg-white"
 			name="alignment"
+			id="alignment"
 			data-1p-ignore
 		/>
 	</div>
+
+	<div class="daisy-form-control w-full max-w-sm m-1">
+		<label class="daisy-label" for="name">
+			<span class="daisy-label-text">Name</span>
+		</label>
+		<input
+			type="text"
+			bind:value={config.name}
+			placeholder={'Referred to as "the dragon" by default'}
+			class="daisy-input daisy-input-bordered bg-white"
+			name="name"
+			id="name"
+			data-1p-ignore
+		/>
+	</div>
+
+	<div class="daisy-form-control flex-row gap-2 items-center m-1 w-full max-w-sm">
+		<input
+			type="checkbox"
+			bind:checked={config.disableNameCapitalization}
+			class="daisy-checkbox cursor-pointer"
+			name="disableNameCapitalization"
+			id="disableNameCapitalization"
+		/>
+		<label class="daisy-label daisy-label-text" for="disableNameCapitalization">
+			Disable name capitalization at starts of sentences
+		</label>
+	</div>
+
+	<div class="daisy-form-control w-full max-w-sm m-1">
+		<label class="daisy-label" for="statBlockTitle">
+			<span class="daisy-label-text">Stat Block Title</span>
+		</label>
+		<input
+			type="text"
+			bind:value={config.statBlockTitle}
+			placeholder={'Defaults to name and a descriptive title'}
+			class="daisy-input daisy-input-bordered bg-white"
+			name="statBlockTitle"
+			id="statBlockTitle"
+			data-1p-ignore
+		/>
+	</div>
+
+	<!-- Pronouns -->
 </div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
@@ -20,158 +20,156 @@
 	}
 </script>
 
-<div class="flex flex-col items-center w-full">
-	<FormSubsectionWelcome {config} />
+<FormSubsectionWelcome {config} />
 
-	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="name">
-			<span class="daisy-label-text">Name</span>
-		</label>
-		<input
-			type="text"
-			bind:value={config.name}
-			placeholder={'Referred to as "the dragon" by default'}
-			class="daisy-input daisy-input-bordered bg-white"
-			name="name"
-			id="name"
-			data-1p-ignore
-		/>
-	</div>
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="name">
+		<span class="daisy-label-text">Name</span>
+	</label>
+	<input
+		type="text"
+		bind:value={config.name}
+		placeholder={'Referred to as "the dragon" by default'}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="name"
+		id="name"
+		data-1p-ignore
+	/>
+</div>
 
+<div class="daisy-form-control flex-row gap-2 items-center m-1 w-full max-w-sm">
+	<input
+		type="checkbox"
+		bind:checked={config.disableNameCapitalization}
+		class="daisy-checkbox cursor-pointer"
+		name="disableNameCapitalization"
+		id="disableNameCapitalization"
+	/>
+	<label class="daisy-label daisy-label-text" for="disableNameCapitalization">
+		Disable name capitalization at starts of sentences
+	</label>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="statBlockTitle">
+		<span class="daisy-label-text">Stat Block Title</span>
+	</label>
+	<input
+		type="text"
+		bind:value={config.statBlockTitle}
+		placeholder={'Defaults to name and a descriptive title'}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="statBlockTitle"
+		id="statBlockTitle"
+		data-1p-ignore
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="alignment">
+		<span class="daisy-label-text">Alignment</span>
+	</label>
+	<input
+		type="text"
+		bind:value={config.alignment}
+		placeholder="Defaults to typical alignment for this color"
+		class="daisy-input daisy-input-bordered bg-white"
+		name="alignment"
+		id="alignment"
+		data-1p-ignore
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="languages">
+		<span class="daisy-label-text">Languages</span>
+	</label>
+	<input
+		type="text"
+		bind:value={config.languages}
+		placeholder="Defaults to typical languages for this age"
+		class="daisy-input daisy-input-bordered bg-white"
+		name="languages"
+		id="languages"
+		data-1p-ignore
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="pronouns">
+		<span class="daisy-label-text">Pronouns</span>
+	</label>
+	<select
+		bind:value={config.pronouns}
+		class="daisy-select daisy-select-bordered bg-white"
+		name="pronouns"
+		id="pronouns"
+	>
+		<option value="it-its">It/Its</option>
+		<option value="she-her">She/Her</option>
+		<option value="he-him">He/Him</option>
+		<option value="they-them">They/Them</option>
+		<option value="none">None</option>
+		<option value="custom">Custom</option>
+	</select>
+</div>
+
+{#if config.pronouns === 'custom'}
 	<div class="daisy-form-control flex-row gap-2 items-center m-1 w-full max-w-sm">
 		<input
 			type="checkbox"
-			bind:checked={config.disableNameCapitalization}
+			bind:checked={customPronounsConfig.plural}
 			class="daisy-checkbox cursor-pointer"
-			name="disableNameCapitalization"
-			id="disableNameCapitalization"
+			name="pronounsPlural"
+			id="pronounsPlural"
 		/>
-		<label class="daisy-label daisy-label-text" for="disableNameCapitalization">
-			Disable name capitalization at starts of sentences
+		<label class="daisy-label daisy-label-text" for="pronounsPlural">
+			Pronouns are grammatically plural (like they/them)
 		</label>
 	</div>
 
 	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="statBlockTitle">
-			<span class="daisy-label-text">Stat Block Title</span>
+		<label class="daisy-label" for="nominativePronoun">
+			<span class="daisy-label-text">Nominative Pronoun</span>
 		</label>
 		<input
 			type="text"
-			bind:value={config.statBlockTitle}
-			placeholder={'Defaults to name and a descriptive title'}
+			bind:value={customPronounsConfig.nominative}
+			placeholder="e.g. he, she, they, ey"
 			class="daisy-input daisy-input-bordered bg-white"
-			name="statBlockTitle"
-			id="statBlockTitle"
+			name="nominativePronoun"
+			id="nominativePronoun"
 			data-1p-ignore
 		/>
 	</div>
 
 	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="alignment">
-			<span class="daisy-label-text">Alignment</span>
+		<label class="daisy-label" for="objectivePronoun">
+			<span class="daisy-label-text">Objective Pronoun</span>
 		</label>
 		<input
 			type="text"
-			bind:value={config.alignment}
-			placeholder="Defaults to typical alignment for this color"
+			bind:value={customPronounsConfig.objective}
+			placeholder="e.g. him, her, them, em"
 			class="daisy-input daisy-input-bordered bg-white"
-			name="alignment"
-			id="alignment"
+			name="objectivePronoun"
+			id="objectivePronoun"
 			data-1p-ignore
 		/>
 	</div>
 
 	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="languages">
-			<span class="daisy-label-text">Languages</span>
+		<label class="daisy-label" for="possessiveAdjectivePronoun">
+			<span class="daisy-label-text">Possessive Adjective</span>
 		</label>
 		<input
 			type="text"
-			bind:value={config.languages}
-			placeholder="Defaults to typical languages for this age"
+			bind:value={customPronounsConfig.possessiveAdjective}
+			placeholder="e.g. his, her, their, eir"
 			class="daisy-input daisy-input-bordered bg-white"
-			name="languages"
-			id="languages"
+			name="possessiveAdjectivePronoun"
+			id="possessiveAdjectivePronoun"
 			data-1p-ignore
 		/>
 	</div>
-
-	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="pronouns">
-			<span class="daisy-label-text">Pronouns</span>
-		</label>
-		<select
-			bind:value={config.pronouns}
-			class="daisy-select daisy-select-bordered bg-white"
-			name="pronouns"
-			id="pronouns"
-		>
-			<option value="it-its">It/Its</option>
-			<option value="she-her">She/Her</option>
-			<option value="he-him">He/Him</option>
-			<option value="they-them">They/Them</option>
-			<option value="none">None</option>
-			<option value="custom">Custom</option>
-		</select>
-	</div>
-
-	{#if config.pronouns === 'custom'}
-		<div class="daisy-form-control flex-row gap-2 items-center m-1 w-full max-w-sm">
-			<input
-				type="checkbox"
-				bind:checked={customPronounsConfig.plural}
-				class="daisy-checkbox cursor-pointer"
-				name="pronounsPlural"
-				id="pronounsPlural"
-			/>
-			<label class="daisy-label daisy-label-text" for="pronounsPlural">
-				Pronouns are grammatically plural (like they/them)
-			</label>
-		</div>
-
-		<div class="daisy-form-control w-full max-w-sm m-1">
-			<label class="daisy-label" for="nominativePronoun">
-				<span class="daisy-label-text">Nominative Pronoun</span>
-			</label>
-			<input
-				type="text"
-				bind:value={customPronounsConfig.nominative}
-				placeholder="e.g. he, she, they, ey"
-				class="daisy-input daisy-input-bordered bg-white"
-				name="nominativePronoun"
-				id="nominativePronoun"
-				data-1p-ignore
-			/>
-		</div>
-
-		<div class="daisy-form-control w-full max-w-sm m-1">
-			<label class="daisy-label" for="objectivePronoun">
-				<span class="daisy-label-text">Objective Pronoun</span>
-			</label>
-			<input
-				type="text"
-				bind:value={customPronounsConfig.objective}
-				placeholder="e.g. him, her, them, em"
-				class="daisy-input daisy-input-bordered bg-white"
-				name="objectivePronoun"
-				id="objectivePronoun"
-				data-1p-ignore
-			/>
-		</div>
-
-		<div class="daisy-form-control w-full max-w-sm m-1">
-			<label class="daisy-label" for="possessiveAdjectivePronoun">
-				<span class="daisy-label-text">Possessive Adjective</span>
-			</label>
-			<input
-				type="text"
-				bind:value={customPronounsConfig.possessiveAdjective}
-				placeholder="e.g. his, her, their, eir"
-				class="daisy-input daisy-input-bordered bg-white"
-				name="possessiveAdjectivePronoun"
-				id="possessiveAdjectivePronoun"
-				data-1p-ignore
-			/>
-		</div>
-	{/if}
-</div>
+{/if}

--- a/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
@@ -1,8 +1,23 @@
 <script lang="ts">
-	import type { DragonConfig } from '$lib/dragon';
+	import type { DragonConfig, PronounsConfig } from '$lib/dragon';
 	import FormSubsectionWelcome from './FormSubsectionWelcome.svelte';
 
 	export let config: DragonConfig;
+
+	let customPronounsConfig: PronounsConfig = {
+		plural: false,
+		nominative: '',
+		objective: '',
+		possessiveAdjective: ''
+	};
+
+	$: if (config.pronouns !== 'custom') {
+		config.pronounsConfig = undefined;
+	} else if (config.pronounsConfig !== undefined) {
+		customPronounsConfig = config.pronounsConfig;
+	} else {
+		config.pronounsConfig = customPronounsConfig;
+	}
 </script>
 
 <div class="flex flex-col items-center w-full">
@@ -99,4 +114,64 @@
 			<option value="custom">Custom</option>
 		</select>
 	</div>
+
+	{#if config.pronouns === 'custom'}
+		<div class="daisy-form-control flex-row gap-2 items-center m-1 w-full max-w-sm">
+			<input
+				type="checkbox"
+				bind:checked={customPronounsConfig.plural}
+				class="daisy-checkbox cursor-pointer"
+				name="pronounsPlural"
+				id="pronounsPlural"
+			/>
+			<label class="daisy-label daisy-label-text" for="pronounsPlural">
+				Pronouns are grammatically plural (like they/them)
+			</label>
+		</div>
+
+		<div class="daisy-form-control w-full max-w-sm m-1">
+			<label class="daisy-label" for="nominativePronoun">
+				<span class="daisy-label-text">Nominative Pronoun</span>
+			</label>
+			<input
+				type="text"
+				bind:value={customPronounsConfig.nominative}
+				placeholder="e.g. he, she, they, ey"
+				class="daisy-input daisy-input-bordered bg-white"
+				name="nominativePronoun"
+				id="nominativePronoun"
+				data-1p-ignore
+			/>
+		</div>
+
+		<div class="daisy-form-control w-full max-w-sm m-1">
+			<label class="daisy-label" for="objectivePronoun">
+				<span class="daisy-label-text">Objective Pronoun</span>
+			</label>
+			<input
+				type="text"
+				bind:value={customPronounsConfig.objective}
+				placeholder="e.g. him, her, them, em"
+				class="daisy-input daisy-input-bordered bg-white"
+				name="objectivePronoun"
+				id="objectivePronoun"
+				data-1p-ignore
+			/>
+		</div>
+
+		<div class="daisy-form-control w-full max-w-sm m-1">
+			<label class="daisy-label" for="possessiveAdjectivePronoun">
+				<span class="daisy-label-text">Possessive Adjective</span>
+			</label>
+			<input
+				type="text"
+				bind:value={customPronounsConfig.possessiveAdjective}
+				placeholder="e.g. his, her, their, eir"
+				class="daisy-input daisy-input-bordered bg-white"
+				name="possessiveAdjectivePronoun"
+				id="possessiveAdjectivePronoun"
+				data-1p-ignore
+			/>
+		</div>
+	{/if}
 </div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
@@ -9,21 +9,6 @@
 	<FormSubsectionWelcome {config} />
 
 	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for="alignment">
-			<span class="daisy-label-text">Alignment</span>
-		</label>
-		<input
-			type="text"
-			bind:value={config.alignment}
-			placeholder="Defaults to typical alignment for this color"
-			class="daisy-input daisy-input-bordered bg-white"
-			name="alignment"
-			id="alignment"
-			data-1p-ignore
-		/>
-	</div>
-
-	<div class="daisy-form-control w-full max-w-sm m-1">
 		<label class="daisy-label" for="name">
 			<span class="daisy-label-text">Name</span>
 		</label>
@@ -62,6 +47,36 @@
 			class="daisy-input daisy-input-bordered bg-white"
 			name="statBlockTitle"
 			id="statBlockTitle"
+			data-1p-ignore
+		/>
+	</div>
+
+	<div class="daisy-form-control w-full max-w-sm m-1">
+		<label class="daisy-label" for="alignment">
+			<span class="daisy-label-text">Alignment</span>
+		</label>
+		<input
+			type="text"
+			bind:value={config.alignment}
+			placeholder="Defaults to typical alignment for this color"
+			class="daisy-input daisy-input-bordered bg-white"
+			name="alignment"
+			id="alignment"
+			data-1p-ignore
+		/>
+	</div>
+
+	<div class="daisy-form-control w-full max-w-sm m-1">
+		<label class="daisy-label" for="languages">
+			<span class="daisy-label-text">Languages</span>
+		</label>
+		<input
+			type="text"
+			bind:value={config.languages}
+			placeholder="Defaults to typical languages for this age"
+			class="daisy-input daisy-input-bordered bg-white"
+			name="languages"
+			id="languages"
 			data-1p-ignore
 		/>
 	</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
@@ -81,5 +81,22 @@
 		/>
 	</div>
 
-	<!-- Pronouns -->
+	<div class="daisy-form-control w-full max-w-sm m-1">
+		<label class="daisy-label" for="pronouns">
+			<span class="daisy-label-text">Pronouns</span>
+		</label>
+		<select
+			bind:value={config.pronouns}
+			class="daisy-select daisy-select-bordered bg-white"
+			name="pronouns"
+			id="pronouns"
+		>
+			<option value="it-its">It/Its</option>
+			<option value="she-her">She/Her</option>
+			<option value="he-him">He/Him</option>
+			<option value="they-them">They/Them</option>
+			<option value="none">None</option>
+			<option value="custom">Custom</option>
+		</select>
+	</div>
 </div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { DragonConfig } from '$lib/dragon';
+	import FormSubsectionWelcome from './FormSubsectionWelcome.svelte';
+
+	export let config: DragonConfig;
+</script>
+
+<div class="flex flex-col items-center w-full">
+	<FormSubsectionWelcome {config} />
+
+	<div class="daisy-form-control w-full max-w-sm m-1">
+		<label class="daisy-label" for="name">
+			<span class="daisy-label-text">Name</span>
+		</label>
+		<input
+			type="text"
+			bind:value={config.name}
+			placeholder={'Referred to as "the dragon" by default'}
+			class="daisy-input daisy-input-bordered bg-white"
+			name="name"
+			data-1p-ignore
+		/>
+	</div>
+
+	<div class="daisy-form-control w-full max-w-sm m-1">
+		<label class="daisy-label" for="alignment">
+			<span class="daisy-label-text">Alignment</span>
+		</label>
+		<input
+			type="text"
+			bind:value={config.alignment}
+			placeholder="Defaults to typical alignment for this color"
+			class="daisy-input daisy-input-bordered bg-white"
+			name="alignment"
+			data-1p-ignore
+		/>
+	</div>
+</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
@@ -4,4 +4,4 @@
 	export let config: DragonConfig;
 </script>
 
-<div>This is the FormSectionHPAbilities. {config}</div>
+<div>Coming soon!</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import type { DragonConfig } from '$lib/dragon';
+
+	export let config: DragonConfig;
+</script>
+
+<div>This is the FormSectionHPAbilities. {config}</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
@@ -1,7 +1,24 @@
 <script lang="ts">
-	import type { DragonConfig } from '$lib/dragon';
+	import { type DragonConfig, SKILLS } from '$lib/dragon';
 
 	export let config: DragonConfig;
 </script>
 
-<div>This is the FormSectionSkills. {config}</div>
+{#each SKILLS as skill}
+	<div class="daisy-form-control w-full max-w-sm m-1">
+		<label class="daisy-label" for={skill.key}>
+			<span class="daisy-label-text">{skill.name}</span>
+		</label>
+		<select
+			bind:value={config[skill.key]}
+			class="daisy-select daisy-select-bordered bg-white"
+			name={skill.key}
+		>
+			<option value={undefined}>Default Proficiency (Varies based on age and color)</option>
+			<option value={0.0}>Not Proficient</option>
+			<option value={0.5}>Half Proficiency</option>
+			<option value={1.0}>Proficient</option>
+			<option value={2.0}>Expertise (Double Proficiency)</option>
+		</select>
+	</div>
+{/each}

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
@@ -5,13 +5,13 @@
 </script>
 
 {#each SKILLS as skill}
-	<div class="daisy-form-control w-full max-w-sm m-1">
-		<label class="daisy-label" for={skill.key}>
+	<div class="daisy-form-control w-full max-w-xl m-1 flex-row flex-wrap items-center">
+		<label class="daisy-label w-1/3 sm:w-1/4 text-left" for={skill.key}>
 			<span class="daisy-label-text">{skill.name}</span>
 		</label>
 		<select
 			bind:value={config[skill.key]}
-			class="daisy-select daisy-select-bordered bg-white"
+			class="daisy-select daisy-select-bordered bg-white w-2/3 sm:w-3/4"
 			name={skill.key}
 		>
 			<option value={undefined}>Default Proficiency ({skill.defaultDescription})</option>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
@@ -17,10 +17,10 @@
 				id={skill.key}
 			>
 				<option value={undefined}>Default Proficiency ({skill.defaultDescription})</option>
-				<option value={0.0}>Not Proficient</option>
-				<option value={0.5}>Half Proficiency</option>
-				<option value={1.0}>Proficient</option>
-				<option value={2.0}>Expertise (Double Proficiency)</option>
+				<option value={0.0}>Not Proficient (0x proficiency)</option>
+				<option value={0.5}>Half Proficiency (0.5x proficiency)</option>
+				<option value={1.0}>Proficient (1x proficiency)</option>
+				<option value={2.0}>Expertise (2x proficiency)</option>
 			</select>
 		</div>
 	{/each}

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import type { DragonConfig } from '$lib/dragon';
+
+	export let config: DragonConfig;
+</script>
+
+<div>This is the FormSectionSkills. {config}</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
@@ -4,24 +4,22 @@
 	export let config: DragonConfig;
 </script>
 
-<div class="flex flex-col items-center">
-	{#each SKILLS as skill}
-		<div class="daisy-form-control w-full max-w-xl m-1 flex-row flex-wrap items-center">
-			<label class="daisy-label w-1/3 sm:w-1/4 text-left" for={skill.key}>
-				<span class="daisy-label-text">{skill.name}</span>
-			</label>
-			<select
-				bind:value={config[skill.key]}
-				class="daisy-select daisy-select-bordered bg-white w-2/3 sm:w-3/4"
-				name={skill.key}
-				id={skill.key}
-			>
-				<option value={undefined}>Default Proficiency ({skill.defaultDescription})</option>
-				<option value={0.0}>Not Proficient (0x proficiency)</option>
-				<option value={0.5}>Half Proficiency (0.5x proficiency)</option>
-				<option value={1.0}>Proficient (1x proficiency)</option>
-				<option value={2.0}>Expertise (2x proficiency)</option>
-			</select>
-		</div>
-	{/each}
-</div>
+{#each SKILLS as skill}
+	<div class="daisy-form-control w-full max-w-xl m-1 flex-row flex-wrap items-center">
+		<label class="daisy-label w-1/3 sm:w-1/4 text-left" for={skill.key}>
+			<span class="daisy-label-text">{skill.name}</span>
+		</label>
+		<select
+			bind:value={config[skill.key]}
+			class="daisy-select daisy-select-bordered bg-white w-2/3 sm:w-3/4"
+			name={skill.key}
+			id={skill.key}
+		>
+			<option value={undefined}>Default Proficiency ({skill.defaultDescription})</option>
+			<option value={0.0}>Not Proficient (0x proficiency)</option>
+			<option value={0.5}>Half Proficiency (0.5x proficiency)</option>
+			<option value={1.0}>Proficient (1x proficiency)</option>
+			<option value={2.0}>Expertise (2x proficiency)</option>
+		</select>
+	</div>
+{/each}

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
@@ -13,6 +13,7 @@
 			bind:value={config[skill.key]}
 			class="daisy-select daisy-select-bordered bg-white w-2/3 sm:w-3/4"
 			name={skill.key}
+			id={skill.key}
 		>
 			<option value={undefined}>Default Proficiency ({skill.defaultDescription})</option>
 			<option value={0.0}>Not Proficient</option>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
@@ -4,22 +4,24 @@
 	export let config: DragonConfig;
 </script>
 
-{#each SKILLS as skill}
-	<div class="daisy-form-control w-full max-w-xl m-1 flex-row flex-wrap items-center">
-		<label class="daisy-label w-1/3 sm:w-1/4 text-left" for={skill.key}>
-			<span class="daisy-label-text">{skill.name}</span>
-		</label>
-		<select
-			bind:value={config[skill.key]}
-			class="daisy-select daisy-select-bordered bg-white w-2/3 sm:w-3/4"
-			name={skill.key}
-			id={skill.key}
-		>
-			<option value={undefined}>Default Proficiency ({skill.defaultDescription})</option>
-			<option value={0.0}>Not Proficient</option>
-			<option value={0.5}>Half Proficiency</option>
-			<option value={1.0}>Proficient</option>
-			<option value={2.0}>Expertise (Double Proficiency)</option>
-		</select>
-	</div>
-{/each}
+<div class="flex flex-col items-center">
+	{#each SKILLS as skill}
+		<div class="daisy-form-control w-full max-w-xl m-1 flex-row flex-wrap items-center">
+			<label class="daisy-label w-1/3 sm:w-1/4 text-left" for={skill.key}>
+				<span class="daisy-label-text">{skill.name}</span>
+			</label>
+			<select
+				bind:value={config[skill.key]}
+				class="daisy-select daisy-select-bordered bg-white w-2/3 sm:w-3/4"
+				name={skill.key}
+				id={skill.key}
+			>
+				<option value={undefined}>Default Proficiency ({skill.defaultDescription})</option>
+				<option value={0.0}>Not Proficient</option>
+				<option value={0.5}>Half Proficiency</option>
+				<option value={1.0}>Proficient</option>
+				<option value={2.0}>Expertise (Double Proficiency)</option>
+			</select>
+		</div>
+	{/each}
+</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSkills.svelte
@@ -14,7 +14,7 @@
 			class="daisy-select daisy-select-bordered bg-white"
 			name={skill.key}
 		>
-			<option value={undefined}>Default Proficiency (Varies based on age and color)</option>
+			<option value={undefined}>Default Proficiency ({skill.defaultDescription})</option>
 			<option value={0.0}>Not Proficient</option>
 			<option value={0.5}>Half Proficiency</option>
 			<option value={1.0}>Proficient</option>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSpells.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSpells.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import type { DragonConfig } from '$lib/dragon';
+
+	export let config: DragonConfig;
+</script>
+
+<div>This is the FormSectionSpells. {config}</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSpells.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSpells.svelte
@@ -4,4 +4,4 @@
 	export let config: DragonConfig;
 </script>
 
-<div>This is the FormSectionSpells. {config}</div>
+<div>Coming soon!</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSubsectionWelcome.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSubsectionWelcome.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { type DragonConfig, COLORS, COLORS_UPPER, AGES, AGES_UPPER } from '$lib/dragon';
+
+	export let config: DragonConfig;
+</script>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="age">
+		<span class="daisy-label-text">Age</span>
+	</label>
+	<select bind:value={config.age} class="daisy-select daisy-select-bordered bg-white" name="age">
+		{#each AGES as age, index}
+			<option value={age}>{AGES_UPPER[index]}</option>
+		{/each}
+	</select>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="color">
+		<span class="daisy-label-text">Color</span>
+	</label>
+	<select
+		bind:value={config.color}
+		class="daisy-select daisy-select-bordered bg-white"
+		name="color"
+	>
+		{#each COLORS as color, index}
+			<option value={color}>{COLORS_UPPER[index]}</option>
+		{/each}
+	</select>
+</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSubsectionWelcome.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSubsectionWelcome.svelte
@@ -8,7 +8,12 @@
 	<label class="daisy-label" for="age">
 		<span class="daisy-label-text">Age</span>
 	</label>
-	<select bind:value={config.age} class="daisy-select daisy-select-bordered bg-white" name="age">
+	<select
+		bind:value={config.age}
+		class="daisy-select daisy-select-bordered bg-white"
+		name="age"
+		id="age"
+	>
 		{#each AGES as age, index}
 			<option value={age}>{AGES_UPPER[index]}</option>
 		{/each}
@@ -23,6 +28,7 @@
 		bind:value={config.color}
 		class="daisy-select daisy-select-bordered bg-white"
 		name="color"
+		id="color"
 	>
 		{#each COLORS as color, index}
 			<option value={color}>{COLORS_UPPER[index]}</option>

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -38,7 +38,10 @@ export class DragonStats {
 
 		this.theme = this.#config.getTheme();
 		this.name = this.#config.name ?? 'the dragon';
-		this.nameUpper = capitalizeFirstLetter(this.name);
+		this.nameUpper =
+			this.#config.disableNameCapitalization === true
+				? this.name
+				: capitalizeFirstLetter(this.name);
 		this.title = this.#config.getTitle();
 		this.alignment = this.#config.alignment ?? COLOR_TO_ALIGNMENT[this.color];
 

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -9,7 +9,7 @@ import {
 	expectedDiceResult,
 	capitalizeFirstLetter
 } from '.';
-import type { Age, Color, RGB, Size, Die } from '.';
+import type { Age, Color, RGB, Size, Die, ProficiencyLevel } from '.';
 import { DRAGON_VALS, type DragonVals } from './dragon-vals';
 import { type CR, CRNumberToString, CR_TABLE } from './challenge-rating';
 
@@ -105,24 +105,24 @@ export class DragonStats {
 		this.saveDCWis = 8 + this.wis + this.proficiencyBonus;
 		this.saveDCCha = 8 + this.cha + this.proficiencyBonus;
 
-		this.skillAcrobatics = this.#vals.skillAcrobatics;
-		this.skillAnimalHandling = this.#vals.skillAnimalHandling;
-		this.skillArcana = this.#vals.skillArcana;
-		this.skillAthletics = this.#vals.skillAthletics;
-		this.skillDeception = this.#vals.skillDeception;
-		this.skillHistory = this.#vals.skillHistory;
-		this.skillInsight = this.#vals.skillInsight;
-		this.skillIntimidation = this.#vals.skillIntimidation;
-		this.skillInvestigation = this.#vals.skillInvestigation;
-		this.skillMedicine = this.#vals.skillMedicine;
-		this.skillNature = this.#vals.skillNature;
-		this.skillPerception = this.#vals.skillPerception;
-		this.skillPerformance = this.#vals.skillPerformance;
-		this.skillPersuasion = this.#vals.skillPersuasion;
-		this.skillReligion = this.#vals.skillReligion;
-		this.skillSleightOfHand = this.#vals.skillSleightOfHand;
-		this.skillStealth = this.#vals.skillStealth;
-		this.skillSurvival = this.#vals.skillSurvival;
+		this.skillAcrobatics = this.#config.skillAcrobatics ?? this.#vals.skillAcrobatics;
+		this.skillAnimalHandling = this.#config.skillAnimalHandling ?? this.#vals.skillAnimalHandling;
+		this.skillArcana = this.#config.skillArcana ?? this.#vals.skillArcana;
+		this.skillAthletics = this.#config.skillAthletics ?? this.#vals.skillAthletics;
+		this.skillDeception = this.#config.skillDeception ?? this.#vals.skillDeception;
+		this.skillHistory = this.#config.skillHistory ?? this.#vals.skillHistory;
+		this.skillInsight = this.#config.skillInsight ?? this.#vals.skillInsight;
+		this.skillIntimidation = this.#config.skillIntimidation ?? this.#vals.skillIntimidation;
+		this.skillInvestigation = this.#config.skillInvestigation ?? this.#vals.skillInvestigation;
+		this.skillMedicine = this.#config.skillMedicine ?? this.#vals.skillMedicine;
+		this.skillNature = this.#config.skillNature ?? this.#vals.skillNature;
+		this.skillPerception = this.#config.skillPerception ?? this.#vals.skillPerception;
+		this.skillPerformance = this.#config.skillPerformance ?? this.#vals.skillPerformance;
+		this.skillPersuasion = this.#config.skillPersuasion ?? this.#vals.skillPersuasion;
+		this.skillReligion = this.#config.skillReligion ?? this.#vals.skillReligion;
+		this.skillSleightOfHand = this.#config.skillSleightOfHand ?? this.#vals.skillSleightOfHand;
+		this.skillStealth = this.#config.skillStealth ?? this.#vals.skillStealth;
+		this.skillSurvival = this.#config.skillSurvival ?? this.#vals.skillSurvival;
 
 		this.skills = this.#getSkills();
 
@@ -357,24 +357,24 @@ export class DragonStats {
 	saveDCWis: number;
 	saveDCCha: number;
 
-	skillAcrobatics: number;
-	skillAnimalHandling: number;
-	skillArcana: number;
-	skillAthletics: number;
-	skillDeception: number;
-	skillHistory: number;
-	skillInsight: number;
-	skillIntimidation: number;
-	skillInvestigation: number;
-	skillMedicine: number;
-	skillNature: number;
-	skillPerception: number;
-	skillPerformance: number;
-	skillPersuasion: number;
-	skillReligion: number;
-	skillSleightOfHand: number;
-	skillStealth: number;
-	skillSurvival: number;
+	skillAcrobatics: ProficiencyLevel;
+	skillAnimalHandling: ProficiencyLevel;
+	skillArcana: ProficiencyLevel;
+	skillAthletics: ProficiencyLevel;
+	skillDeception: ProficiencyLevel;
+	skillHistory: ProficiencyLevel;
+	skillInsight: ProficiencyLevel;
+	skillIntimidation: ProficiencyLevel;
+	skillInvestigation: ProficiencyLevel;
+	skillMedicine: ProficiencyLevel;
+	skillNature: ProficiencyLevel;
+	skillPerception: ProficiencyLevel;
+	skillPerformance: ProficiencyLevel;
+	skillPersuasion: ProficiencyLevel;
+	skillReligion: ProficiencyLevel;
+	skillSleightOfHand: ProficiencyLevel;
+	skillStealth: ProficiencyLevel;
+	skillSurvival: ProficiencyLevel;
 
 	skills: string[];
 

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -93,7 +93,7 @@ export class DragonStats {
 		this.blindsight = this.#vals.blindsight;
 		this.darkvision = this.#vals.darkvision;
 
-		this.languages = this.#vals.languages;
+		this.languages = this.#config.languages ?? this.#vals.languages;
 
 		this.cr = CRNumberToString(this.#vals.cr);
 		this.xp = CR_TABLE[this.cr].xp;

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -4,12 +4,14 @@ import {
 	AGE_TO_SIZE,
 	SIZE_TO_HIT_DIE,
 	SKILLS,
+	DEFAULT_PRONOUNS,
+	BASIC_PRONOUN_CONFIGS,
 	scoreToMod,
 	numberWithSign,
 	expectedDiceResult,
 	capitalizeFirstLetter
 } from '.';
-import type { Age, Color, RGB, Size, Die, ProficiencyLevel } from '.';
+import type { Age, Color, RGB, Size, Die, ProficiencyLevel, PronounsConfig } from '.';
 import { DRAGON_VALS, type DragonVals } from './dragon-vals';
 import { type CR, CRNumberToString, CR_TABLE } from './challenge-rating';
 
@@ -45,9 +47,11 @@ export class DragonStats {
 		this.title = this.#config.getTitle();
 		this.alignment = this.#config.alignment ?? COLOR_TO_ALIGNMENT[this.color];
 
-		this.she = 'she';
-		this.her = 'her';
-		this.hers = 'hers';
+		const pronouns = this.#getPronounsConfig();
+		this.pronounsPlural = pronouns.plural;
+		this.pronounNominative = pronouns.nominative;
+		this.pronounObjective = pronouns.objective;
+		this.pronounPossessiveAdjective = pronouns.possessiveAdjective;
 
 		this.size = AGE_TO_SIZE[this.age];
 		this.ac = this.#vals.ac;
@@ -220,6 +224,39 @@ export class DragonStats {
 		}
 	}
 
+	#getPronounsConfig(): PronounsConfig {
+		const nonePronounsConfig: PronounsConfig = {
+			plural: false,
+			nominative: this.name,
+			objective: this.name,
+			possessiveAdjective: `${this.name}'s`
+		};
+		if (this.#config.pronouns === undefined || this.#config.pronouns === DEFAULT_PRONOUNS) {
+			return BASIC_PRONOUN_CONFIGS[DEFAULT_PRONOUNS];
+		} else if (this.#config.pronouns === 'none') {
+			return nonePronounsConfig;
+		} else if (this.#config.pronouns === 'custom') {
+			// for custom options not specified, default to nonePronounsConfig
+			const customPronounsConfig = nonePronounsConfig;
+			if (this.#config.pronounsConfig !== undefined) {
+				customPronounsConfig.plural = this.#config.pronounsConfig.plural;
+				if (this.#config.pronounsConfig.nominative !== '') {
+					customPronounsConfig.nominative = this.#config.pronounsConfig.nominative;
+				}
+				if (this.#config.pronounsConfig.objective !== '') {
+					customPronounsConfig.objective = this.#config.pronounsConfig.objective;
+				}
+				if (this.#config.pronounsConfig.possessiveAdjective !== '') {
+					customPronounsConfig.possessiveAdjective =
+						this.#config.pronounsConfig.possessiveAdjective;
+				}
+			}
+			return customPronounsConfig;
+		} else {
+			return BASIC_PRONOUN_CONFIGS[this.#config.pronouns];
+		}
+	}
+
 	#getSpeeds(): string {
 		let output = `${this.speed} ft.`;
 		if (this.burrowSpeed > 0) {
@@ -302,9 +339,10 @@ export class DragonStats {
 	title: string;
 	alignment: string;
 
-	she: string;
-	her: string;
-	hers: string;
+	pronounsPlural: boolean;
+	pronounNominative: string;
+	pronounObjective: string;
+	pronounPossessiveAdjective: string;
 
 	size: Size;
 	ac: number;

--- a/src/lib/dragon/dragon-vals.ts
+++ b/src/lib/dragon/dragon-vals.ts
@@ -1,4 +1,4 @@
-import type { Color, Age, Die } from '.';
+import type { Color, Age, Die, ProficiencyLevel } from '.';
 import type { CRNumber } from './challenge-rating';
 
 // TODO: Remove the following values, as they are not needed:
@@ -33,24 +33,24 @@ export type DragonVals = {
 	intelligence: number;
 	wisdom: number;
 	charisma: number;
-	skillAcrobatics: number;
-	skillAnimalHandling: number;
-	skillArcana: number;
-	skillAthletics: number;
-	skillDeception: number;
-	skillHistory: number;
-	skillInsight: number;
-	skillIntimidation: number;
-	skillInvestigation: number;
-	skillMedicine: number;
-	skillNature: number;
-	skillPerception: number;
-	skillPerformance: number;
-	skillPersuasion: number;
-	skillReligion: number;
-	skillSleightOfHand: number;
-	skillStealth: number;
-	skillSurvival: number;
+	skillAcrobatics: ProficiencyLevel;
+	skillAnimalHandling: ProficiencyLevel;
+	skillArcana: ProficiencyLevel;
+	skillAthletics: ProficiencyLevel;
+	skillDeception: ProficiencyLevel;
+	skillHistory: ProficiencyLevel;
+	skillInsight: ProficiencyLevel;
+	skillIntimidation: ProficiencyLevel;
+	skillInvestigation: ProficiencyLevel;
+	skillMedicine: ProficiencyLevel;
+	skillNature: ProficiencyLevel;
+	skillPerception: ProficiencyLevel;
+	skillPerformance: ProficiencyLevel;
+	skillPersuasion: ProficiencyLevel;
+	skillReligion: ProficiencyLevel;
+	skillSleightOfHand: ProficiencyLevel;
+	skillStealth: ProficiencyLevel;
+	skillSurvival: ProficiencyLevel;
 	conditionImmunities: string;
 	blindsight: number;
 	darkvision: number;

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -218,7 +218,7 @@ export const SKILLS = [
 		name: 'Perception',
 		key: 'skillPerception',
 		ability: 'wis',
-		defaultDescription: 'Typically double proficiency'
+		defaultDescription: 'Typically 2x proficiency'
 	},
 	{
 		name: 'Performance',
@@ -248,7 +248,7 @@ export const SKILLS = [
 		name: 'Stealth',
 		key: 'skillStealth',
 		ability: 'dex',
-		defaultDescription: 'Typically proficient'
+		defaultDescription: 'Typically 1x proficiency'
 	},
 	{
 		name: 'Survival',

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -334,6 +334,8 @@ export class DragonConfig {
 	color: Color = 'red';
 	name?: string;
 	alignment?: string;
+	disableNameCapitalization?: boolean;
+	statBlockTitle?: string;
 
 	skillAcrobatics?: ProficiencyLevel;
 	skillAnimalHandling?: ProficiencyLevel;
@@ -360,6 +362,10 @@ export class DragonConfig {
 	 * @memberof DragonConfig
 	 */
 	getTitle(): string {
+		if (this.statBlockTitle !== undefined) {
+			return this.statBlockTitle;
+		}
+
 		let output = '';
 
 		let descriptiveTitle = '';
@@ -400,6 +406,12 @@ export class DragonConfig {
 		if (this.alignment === '') {
 			delete this.alignment;
 		}
+		if (this.disableNameCapitalization === false) {
+			delete this.disableNameCapitalization;
+		}
+		if (this.statBlockTitle === '') {
+			delete this.statBlockTitle;
+		}
 	}
 
 	/**
@@ -417,6 +429,12 @@ export class DragonConfig {
 		}
 		if (this.alignment !== undefined) {
 			output.set('alignment', this.alignment);
+		}
+		if (this.disableNameCapitalization === true) {
+			output.set('disableNameCapitalization', 'on');
+		}
+		if (this.statBlockTitle !== undefined) {
+			output.set('statBlockTitle', this.statBlockTitle);
 		}
 
 		for (const skill of SKILLS) {
@@ -469,6 +487,15 @@ export class DragonConfig {
 		const paramsAlignmentVal = params.get('alignment');
 		if (paramsAlignmentVal !== null) {
 			this.alignment = paramsAlignmentVal;
+		}
+
+		if (params.has('disableNameCapitalization') || params.has('forcelowercasename')) {
+			this.disableNameCapitalization = true;
+		}
+
+		const paramsStatBlockTitleVal = params.get('statBlockTitle');
+		if (paramsStatBlockTitleVal !== null) {
+			this.statBlockTitle = paramsStatBlockTitleVal;
 		}
 
 		for (const skill of SKILLS) {

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -147,24 +147,114 @@ export const ABILITIES = [
 ] as const;
 
 export const SKILLS = [
-	{ name: 'Acrobatics', key: 'skillAcrobatics', ability: 'dex' },
-	{ name: 'Animal Handling', key: 'skillAnimalHandling', ability: 'wis' },
-	{ name: 'Arcana', key: 'skillArcana', ability: 'int' },
-	{ name: 'Athletics', key: 'skillAthletics', ability: 'str' },
-	{ name: 'Deception', key: 'skillDeception', ability: 'cha' },
-	{ name: 'History', key: 'skillHistory', ability: 'int' },
-	{ name: 'Insight', key: 'skillInsight', ability: 'wis' },
-	{ name: 'Intimidation', key: 'skillIntimidation', ability: 'cha' },
-	{ name: 'Investigation', key: 'skillInvestigation', ability: 'int' },
-	{ name: 'Medicine', key: 'skillMedicine', ability: 'wis' },
-	{ name: 'Nature', key: 'skillNature', ability: 'int' },
-	{ name: 'Perception', key: 'skillPerception', ability: 'wis' },
-	{ name: 'Performance', key: 'skillPerformance', ability: 'cha' },
-	{ name: 'Persuasion', key: 'skillPersuasion', ability: 'cha' },
-	{ name: 'Religion', key: 'skillReligion', ability: 'int' },
-	{ name: 'Sleight of Hand', key: 'skillSleightOfHand', ability: 'dex' },
-	{ name: 'Stealth', key: 'skillStealth', ability: 'dex' },
-	{ name: 'Survival', key: 'skillSurvival', ability: 'wis' }
+	{
+		name: 'Acrobatics',
+		key: 'skillAcrobatics',
+		ability: 'dex',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Animal Handling',
+		key: 'skillAnimalHandling',
+		ability: 'wis',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Arcana',
+		key: 'skillArcana',
+		ability: 'int',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Athletics',
+		key: 'skillAthletics',
+		ability: 'str',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Deception',
+		key: 'skillDeception',
+		ability: 'cha',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'History',
+		key: 'skillHistory',
+		ability: 'int',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Insight',
+		key: 'skillInsight',
+		ability: 'wis',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Intimidation',
+		key: 'skillIntimidation',
+		ability: 'cha',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Investigation',
+		key: 'skillInvestigation',
+		ability: 'int',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Medicine',
+		key: 'skillMedicine',
+		ability: 'wis',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Nature',
+		key: 'skillNature',
+		ability: 'int',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Perception',
+		key: 'skillPerception',
+		ability: 'wis',
+		defaultDescription: 'Typically double proficiency'
+	},
+	{
+		name: 'Performance',
+		key: 'skillPerformance',
+		ability: 'cha',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Persuasion',
+		key: 'skillPersuasion',
+		ability: 'cha',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Religion',
+		key: 'skillReligion',
+		ability: 'int',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Sleight of Hand',
+		key: 'skillSleightOfHand',
+		ability: 'dex',
+		defaultDescription: 'Varies based on age and color'
+	},
+	{
+		name: 'Stealth',
+		key: 'skillStealth',
+		ability: 'dex',
+		defaultDescription: 'Typically proficient'
+	},
+	{
+		name: 'Survival',
+		key: 'skillSurvival',
+		ability: 'wis',
+		defaultDescription: 'Varies based on age and color'
+	}
 ] as const;
 export type SkillKey = (typeof SKILLS)[number]['key'];
 

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -146,72 +146,73 @@ export const ABILITIES = [
 	['charisma', 'cha']
 ] as const;
 
+const standardDefaultSkillDescription = 'Varies with age and color';
 export const SKILLS = [
 	{
 		name: 'Acrobatics',
 		key: 'skillAcrobatics',
 		ability: 'dex',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Animal Handling',
 		key: 'skillAnimalHandling',
 		ability: 'wis',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Arcana',
 		key: 'skillArcana',
 		ability: 'int',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Athletics',
 		key: 'skillAthletics',
 		ability: 'str',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Deception',
 		key: 'skillDeception',
 		ability: 'cha',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'History',
 		key: 'skillHistory',
 		ability: 'int',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Insight',
 		key: 'skillInsight',
 		ability: 'wis',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Intimidation',
 		key: 'skillIntimidation',
 		ability: 'cha',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Investigation',
 		key: 'skillInvestigation',
 		ability: 'int',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Medicine',
 		key: 'skillMedicine',
 		ability: 'wis',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Nature',
 		key: 'skillNature',
 		ability: 'int',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Perception',
@@ -223,25 +224,25 @@ export const SKILLS = [
 		name: 'Performance',
 		key: 'skillPerformance',
 		ability: 'cha',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Persuasion',
 		key: 'skillPersuasion',
 		ability: 'cha',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Religion',
 		key: 'skillReligion',
 		ability: 'int',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Sleight of Hand',
 		key: 'skillSleightOfHand',
 		ability: 'dex',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	},
 	{
 		name: 'Stealth',
@@ -253,7 +254,7 @@ export const SKILLS = [
 		name: 'Survival',
 		key: 'skillSurvival',
 		ability: 'wis',
-		defaultDescription: 'Varies based on age and color'
+		defaultDescription: standardDefaultSkillDescription
 	}
 ] as const;
 export type SkillKey = (typeof SKILLS)[number]['key'];

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -166,6 +166,9 @@ export const SKILLS = [
 	{ name: 'Stealth', key: 'skillStealth', ability: 'dex' },
 	{ name: 'Survival', key: 'skillSurvival', ability: 'wis' }
 ] as const;
+export type SkillKey = (typeof SKILLS)[number]['key'];
+
+export type ProficiencyLevel = 0.0 | 0.5 | 1.0 | 2.0;
 
 /**
  * Calculates the ability modifier given the ability score.
@@ -241,6 +244,25 @@ export class DragonConfig {
 	name?: string;
 	alignment?: string;
 
+	skillAcrobatics?: ProficiencyLevel;
+	skillAnimalHandling?: ProficiencyLevel;
+	skillArcana?: ProficiencyLevel;
+	skillAthletics?: ProficiencyLevel;
+	skillDeception?: ProficiencyLevel;
+	skillHistory?: ProficiencyLevel;
+	skillInsight?: ProficiencyLevel;
+	skillIntimidation?: ProficiencyLevel;
+	skillInvestigation?: ProficiencyLevel;
+	skillMedicine?: ProficiencyLevel;
+	skillNature?: ProficiencyLevel;
+	skillPerception?: ProficiencyLevel;
+	skillPerformance?: ProficiencyLevel;
+	skillPersuasion?: ProficiencyLevel;
+	skillReligion?: ProficiencyLevel;
+	skillSleightOfHand?: ProficiencyLevel;
+	skillStealth?: ProficiencyLevel;
+	skillSurvival?: ProficiencyLevel;
+
 	/**
 	 * Returns the title for this DragonConfig.
 	 * @return {*}  {string}
@@ -306,6 +328,13 @@ export class DragonConfig {
 			output.set('alignment', this.alignment);
 		}
 
+		for (const skill of SKILLS) {
+			const thisSkillValue = this[skill.key];
+			if (thisSkillValue !== undefined) {
+				output.set(skill.key, thisSkillValue.toString());
+			}
+		}
+
 		return output;
 	}
 
@@ -351,7 +380,26 @@ export class DragonConfig {
 			this.alignment = paramsAlignmentVal;
 		}
 
+		for (const skill of SKILLS) {
+			this.#skillFromURLSearchParams(skill.key, params);
+		}
+
 		return true;
+	}
+
+	#skillFromURLSearchParams(skillKey: SkillKey, params: URLSearchParams) {
+		const paramsSkillVal = params.get(skillKey);
+		if (paramsSkillVal !== null) {
+			const paramsSkillFloat = parseFloat(paramsSkillVal);
+			if (
+				paramsSkillFloat === 0.0 ||
+				paramsSkillFloat === 0.5 ||
+				paramsSkillFloat === 1.0 ||
+				paramsSkillFloat === 2.0
+			) {
+				this[skillKey] = paramsSkillFloat;
+			}
+		}
 	}
 
 	/**

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -605,6 +605,16 @@ export class DragonConfig {
 				this.pronouns = 'none';
 			} else if (paramsPronounsVal === 'custom' || paramsPronounsVal === 'custom-pronouns') {
 				this.pronouns = 'custom';
+			} else if (paramsPronounsVal === 'ey-em' || paramsPronounsVal === 'spivak') {
+				// we want to support these URL options, using them as custom pronouns
+				this.pronouns = 'custom';
+				this.pronounsConfig = {
+					plural: false,
+					nominative: 'ey',
+					objective: 'em',
+					possessiveAdjective: 'eir'
+				};
+				return; // don't check the URL for custom pronouns
 			} else {
 				console.log(`Unable to parse URL pronouns value of ${paramsPronounsVal}`);
 				this.pronouns = undefined;

--- a/src/lib/dragon/stat-block/actions/ActionAttacks.svelte
+++ b/src/lib/dragon/stat-block/actions/ActionAttacks.svelte
@@ -10,8 +10,8 @@
 	<div class="dragon-action break-inside-avoid">
 		<p>
 			<i><b>Multiattack.</b></i>
-			{dragon.nameUpper} makes three attacks: one with {dragon.her}
-			bite and two with {dragon.her} claws.
+			{dragon.nameUpper} makes three attacks: one with {dragon.pronounPossessiveAdjective}
+			bite and two with {dragon.pronounPossessiveAdjective} claws.
 		</p>
 	</div>
 {/if}

--- a/src/lib/dragon/stat-block/actions/breath-weapons/Breath2Violet.svelte
+++ b/src/lib/dragon/stat-block/actions/breath-weapons/Breath2Violet.svelte
@@ -19,11 +19,10 @@
 			After {dragon.breath2SpecialValue}, if the creature is still on that plane, it reappears in
 			the space it left or in the nearest unoccupied space if that space is occupied.
 		{:else}
-			As a bonus action, {dragon.name} can unbanish all the creatures {dragon.she}
-			<span class="affected-by-they" data-they="have">has</span> banished within the last hour. When
-			a creature is unbanished, it reappears in the space it left or in the nearest unoccupied space
-			if that space is occupied. This fails for any creature that is no longer on the plane it was banished
-			to.
+			As a bonus action, {dragon.name} can unbanish all the creatures {dragon.pronounNominative}
+			{dragon.pronounsPlural ? 'have' : 'has'} banished within the last hour. When a creature is unbanished,
+			it reappears in the space it left or in the nearest unoccupied space if that space is occupied.
+			This fails for any creature that is no longer on the plane it was banished to.
 		{/if}
 	</p>
 </div>

--- a/src/lib/dragon/stat-block/bonus-actions/BActionFrightfulFlare.svelte
+++ b/src/lib/dragon/stat-block/bonus-actions/BActionFrightfulFlare.svelte
@@ -8,12 +8,13 @@
 	<div class="dragon-action">
 		<p>
 			<i><b>Frightful Flare (1/Day).</b></i>
-			{dragon.nameUpper} unleashes {dragon.her} inner light, maxing out {dragon.her} Variable Radiance
-			to a radius of {dragon.prismaticRadianceRadius} feet. Each creature of {dragon.name}'s choice
-			within {2 * dragon.prismaticRadianceRadius} feet of {dragon.her} must make a
+			{dragon.nameUpper} unleashes {dragon.pronounPossessiveAdjective} inner light, maxing out {dragon.pronounPossessiveAdjective}
+			Variable Radiance to a radius of {dragon.prismaticRadianceRadius} feet. Each creature of {dragon.name}'s
+			choice within {2 * dragon.prismaticRadianceRadius} feet of {dragon.pronounObjective} must make
+			a
 			<span class="whitespace-nowrap">DC {dragon.saveDCCha}</span>
 			Wisdom saving throw if it can see {dragon.name}. Creatures within {dragon.prismaticRadianceRadius}
-			feet of {dragon.her}
+			feet of {dragon.pronounObjective}
 			have disadvantage on this save. On a failed save, a creature is frightened until the end of {dragon.name}'s
 			next turn.
 		</p>

--- a/src/lib/dragon/stat-block/bonus-actions/BActionVariableRadiance.svelte
+++ b/src/lib/dragon/stat-block/bonus-actions/BActionVariableRadiance.svelte
@@ -10,7 +10,8 @@
 		{dragon.nameUpper} chooses a radius up to {dragon.prismaticRadianceRadius}
 		feet and glows {dragon.color}, shedding bright light in the chosen radius and dim light for an
 		additional distance equal to the chosen radius. {dragon.nameUpper} stops glowing if
-		{dragon.she} <span class="affected-by-they" data-they="die">dies</span> or
-		<span class="affected-by-they" data-they="choose">chooses</span> to stop as a bonus action.
+		{dragon.pronounNominative}
+		{dragon.pronounsPlural ? 'die' : 'dies'} or
+		{dragon.pronounsPlural ? 'choose' : 'chooses'} to stop as a bonus action.
 	</p>
 </div>

--- a/src/lib/dragon/stat-block/features/FeatureLegendaryResistance.svelte
+++ b/src/lib/dragon/stat-block/features/FeatureLegendaryResistance.svelte
@@ -8,7 +8,7 @@
 	<div class="dragon-trait break-inside-avoid">
 		<p>
 			<i><b>Legendary Resistance ({dragon.legendaryResistances}/Day).</b></i> If {dragon.name} fails
-			a saving throw, {dragon.she} can choose to succeed instead.
+			a saving throw, {dragon.pronounNominative} can choose to succeed instead.
 		</p>
 	</div>
 {/if}

--- a/src/lib/dragon/stat-block/legendary-actions/LActionWingAttack.svelte
+++ b/src/lib/dragon/stat-block/legendary-actions/LActionWingAttack.svelte
@@ -8,7 +8,7 @@
 <div class="dragon-legendary-action">
 	<p>
 		<b>Wing Attack (Costs 2 Actions).</b>
-		{dragon.nameUpper} beats {dragon.her} wings. Each creature within {dragon.wingAttackRadius}
+		{dragon.nameUpper} beats {dragon.pronounPossessiveAdjective} wings. Each creature within {dragon.wingAttackRadius}
 		feet of {dragon.name} must succeed on a
 		<span class="whitespace-nowrap">DC {dragon.saveDCStr}</span>
 		Dexterity saving throw or take
@@ -16,7 +16,7 @@
 			>{dragon.wingAttackExpectedDamage} ({dragon.wingAttackDiceCount}d{dragon.wingAttackDiceType}
 			{numberWithSign(dragon.str, ' ')})</span
 		>
-		bludgeoning damage and be knocked prone. {dragon.nameUpper} can then fly up to half {dragon.her}
+		bludgeoning damage and be knocked prone. {dragon.nameUpper} can then fly up to half {dragon.pronounPossessiveAdjective}
 		flying speed.
 	</p>
 </div>

--- a/src/lib/dragon/stat-block/legendary-actions/StatBlockLegendaryActions.svelte
+++ b/src/lib/dragon/stat-block/legendary-actions/StatBlockLegendaryActions.svelte
@@ -18,7 +18,7 @@
 	<p>
 		{dragon.nameUpper} can take 3 legendary actions, choosing from the options below. Only one legendary
 		action option can be used at a time and only at the end of another creature's turn. {dragon.nameUpper}
-		regains spent legendary actions at the start of {dragon.her} turn.
+		regains spent legendary actions at the start of {dragon.pronounPossessiveAdjective} turn.
 	</p>
 
 	<LActionTailAttack {dragon} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,12 @@
-<svelte:head>
-	<title>Petal Quest</title>
-</svelte:head>
+<script lang="ts">
+	import PageMeta from '$lib/PageMeta.svelte';
+</script>
+
+<PageMeta
+	title="Petal Quest"
+	description="Petal Quest is making TTRPG content."
+	url="https://www.petalquest.com/"
+/>
 
 <h1>Petal Quest</h1>
 <p>This is the home page.</p>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,2 +1,6 @@
+<svelte:head>
+	<title>Petal Quest</title>
+</svelte:head>
+
 <h1>Petal Quest</h1>
 <p>This is the home page.</p>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,6 +1,12 @@
-<svelte:head>
-	<title>About - Petal Quest</title>
-</svelte:head>
+<script lang="ts">
+	import PageMeta from '$lib/PageMeta.svelte';
+</script>
+
+<PageMeta
+	title="About - Petal Quest"
+	description="Petal Quest is the publishing title used by Peter and Tal: Peter + Tal = Petal."
+	url="https://www.petalquest.com/about/"
+/>
 
 <h1>About Petal Quest</h1>
 <p>This page will contain info about who we are.</p>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,3 +1,7 @@
+<svelte:head>
+	<title>About - Petal Quest</title>
+</svelte:head>
+
 <h1>About Petal Quest</h1>
 <p>This page will contain info about who we are.</p>
 <p>

--- a/src/routes/dragon-builder/+page.svelte
+++ b/src/routes/dragon-builder/+page.svelte
@@ -6,7 +6,7 @@
 	import { currentDragonConfig } from '$lib/dragon/builder-states';
 
 	const defaultTitle = 'Dragon Builder - Petal Quest';
-	let pageTitle: string;
+	let pageTitle: string = defaultTitle;
 	$: pageTitle =
 		$currentDragonConfig === undefined
 			? defaultTitle

--- a/src/routes/dragon-builder/+page.svelte
+++ b/src/routes/dragon-builder/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-	import DragonBuilder from '$lib/dragon/DragonBuilder.svelte';
 	import { onMount } from 'svelte';
+
+	import PageMeta from '$lib/PageMeta.svelte';
+	import DragonBuilder from '$lib/dragon/DragonBuilder.svelte';
 	import { currentDragonConfig } from '$lib/dragon/builder-states';
 
 	const defaultTitle = 'Dragon Builder - Petal Quest';
@@ -15,8 +17,10 @@
 	});
 </script>
 
-<svelte:head>
-	<title>{pageTitle}</title>
-</svelte:head>
+<PageMeta
+	title={pageTitle}
+	description="Build your own prismatic dragon stat block using the Dragon Builder."
+	url="https://www.petalquest.com/dragon-builder/"
+/>
 
 <DragonBuilder />

--- a/src/routes/dragon-builder/+page.svelte
+++ b/src/routes/dragon-builder/+page.svelte
@@ -1,5 +1,22 @@
-<script>
+<script lang="ts">
 	import DragonBuilder from '$lib/dragon/DragonBuilder.svelte';
+	import { onMount } from 'svelte';
+	import { currentDragonConfig } from '$lib/dragon/builder-states';
+
+	const defaultTitle = 'Dragon Builder - Petal Quest';
+	let pageTitle: string;
+	$: pageTitle =
+		$currentDragonConfig === undefined
+			? defaultTitle
+			: `${$currentDragonConfig.getTitle()} - ${defaultTitle}`;
+
+	onMount(() => {
+		pageTitle = defaultTitle;
+	});
 </script>
+
+<svelte:head>
+	<title>{pageTitle}</title>
+</svelte:head>
 
 <DragonBuilder />

--- a/src/routes/prismatic-dragons/+page.svelte
+++ b/src/routes/prismatic-dragons/+page.svelte
@@ -1,6 +1,12 @@
-<svelte:head>
-	<title>Prismatic Dragons - Petal Quest</title>
-</svelte:head>
+<script lang="ts">
+	import PageMeta from '$lib/PageMeta.svelte';
+</script>
+
+<PageMeta
+	title="Prismatic Dragons - Petal Quest"
+	description="The prismatic dragons are a new family of dragons for D&D 5e."
+	url="https://www.petalquest.com/prismatic-dragons/"
+/>
 
 <h1>The Prismatic Dragons</h1>
 <p>This page will contain info about the Prismatic Dragons.</p>

--- a/src/routes/prismatic-dragons/+page.svelte
+++ b/src/routes/prismatic-dragons/+page.svelte
@@ -1,3 +1,7 @@
+<svelte:head>
+	<title>Prismatic Dragons - Petal Quest</title>
+</svelte:head>
+
 <h1>The Prismatic Dragons</h1>
 <p>This page will contain info about the Prismatic Dragons.</p>
 <p><a href="/">Return to Home.</a></p>


### PR DESCRIPTION
## What's in this PR?
This PR contains the following changes:
- Added the PageMeta component and set reasonable meta properties for each page on the website.
- BuilderHistory has been reformatted. It now has a description at the top.
- The form elements on the Welcome page are now a shared component with the Edit page, reducing code duplication.
- The Edit page has been dramatically improved. I've added full customization options for names, pronouns, and skills.

## 🐢
