### PR TITLE
Completed DragonBuilder Edit options + general cleanup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
 	rules: {
 		'@typescript-eslint/no-inferrable-types': [
-			'error',
+			'warn',
 			{
 				ignoreParameters: true
 			}

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ node_modules
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+
+.github/pull_request_template.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"devDependencies": {
 				"@playwright/test": "^1.28.1",
 				"@skeletonlabs/skeleton": "^2.1.0",
-				"@skeletonlabs/tw-plugin": "^0.1.0",
+				"@skeletonlabs/tw-plugin": "^0.2.0",
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/adapter-static": "^2.0.2",
 				"@sveltejs/kit": "^1.20.4",
@@ -657,9 +657,9 @@
 			}
 		},
 		"node_modules/@skeletonlabs/tw-plugin": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@skeletonlabs/tw-plugin/-/tw-plugin-0.1.0.tgz",
-			"integrity": "sha512-ufnm4FS+s/khuho4yJ/uqfW91u2YXnH3E5N541MtX9XjmoimQzYIcxWyTIuX9AM/brIPP6M6l0et3nRx17CRoQ==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@skeletonlabs/tw-plugin/-/tw-plugin-0.2.0.tgz",
+			"integrity": "sha512-Mtao12JMrmlYvhv9AfvKNBd5qz+v5MImMG9tri++/4FUORAmzB3F3Qq9+ukfdDtoPT/+Q1CRPn1CL05gDxsKSQ==",
 			"dev": true,
 			"peerDependencies": {
 				"tailwindcss": ">=3.0.0"
@@ -4735,9 +4735,9 @@
 			}
 		},
 		"@skeletonlabs/tw-plugin": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@skeletonlabs/tw-plugin/-/tw-plugin-0.1.0.tgz",
-			"integrity": "sha512-ufnm4FS+s/khuho4yJ/uqfW91u2YXnH3E5N541MtX9XjmoimQzYIcxWyTIuX9AM/brIPP6M6l0et3nRx17CRoQ==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@skeletonlabs/tw-plugin/-/tw-plugin-0.2.0.tgz",
+			"integrity": "sha512-Mtao12JMrmlYvhv9AfvKNBd5qz+v5MImMG9tri++/4FUORAmzB3F3Qq9+ukfdDtoPT/+Q1CRPn1CL05gDxsKSQ==",
 			"dev": true,
 			"requires": {}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.1",
 			"devDependencies": {
 				"@playwright/test": "^1.28.1",
-				"@skeletonlabs/skeleton": "^2.0.0",
+				"@skeletonlabs/skeleton": "^2.1.0",
 				"@skeletonlabs/tw-plugin": "^0.1.0",
 				"@sveltejs/adapter-auto": "^2.0.0",
 				"@sveltejs/adapter-static": "^2.0.2",
@@ -645,9 +645,9 @@
 			"dev": true
 		},
 		"node_modules/@skeletonlabs/skeleton": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-2.0.0.tgz",
-			"integrity": "sha512-8SaDK3kEUU57cSb/5a984EbINgnOPzShlkwPkduAhqc71SEqhRvx+RlLEpe1174NAYi00oi//LguIAYuVrSfBA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-2.1.0.tgz",
+			"integrity": "sha512-i+H67MTo9w3BP8dqr0l9qjVWmxEDwLyTqif/+pTmTOpAZpV/B3wqHShtoh0sxminUBSncE3bsNdn694B+6zUnw==",
 			"dev": true,
 			"dependencies": {
 				"esm-env": "1.0.0"
@@ -4726,9 +4726,9 @@
 			"dev": true
 		},
 		"@skeletonlabs/skeleton": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-2.0.0.tgz",
-			"integrity": "sha512-8SaDK3kEUU57cSb/5a984EbINgnOPzShlkwPkduAhqc71SEqhRvx+RlLEpe1174NAYi00oi//LguIAYuVrSfBA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@skeletonlabs/skeleton/-/skeleton-2.1.0.tgz",
+			"integrity": "sha512-i+H67MTo9w3BP8dqr0l9qjVWmxEDwLyTqif/+pTmTOpAZpV/B3wqHShtoh0sxminUBSncE3bsNdn694B+6zUnw==",
 			"dev": true,
 			"requires": {
 				"esm-env": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.28.1",
-		"@skeletonlabs/skeleton": "^2.0.0",
+		"@skeletonlabs/skeleton": "^2.1.0",
 		"@skeletonlabs/tw-plugin": "^0.1.0",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-static": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
 		"test": "npm run test:integration && npm run test:unit",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"update": "npm run update:skeleton",
+		"update:skeleton": "npm i -D @skeletonlabs/skeleton@latest @skeletonlabs/tw-plugin@latest",
 		"lint": "prettier --plugin-search-dir . --check . && eslint .",
 		"format": "prettier --plugin-search-dir . --write .",
 		"test:integration": "playwright test",
@@ -17,7 +19,7 @@
 	"devDependencies": {
 		"@playwright/test": "^1.28.1",
 		"@skeletonlabs/skeleton": "^2.1.0",
-		"@skeletonlabs/tw-plugin": "^0.1.0",
+		"@skeletonlabs/tw-plugin": "^0.2.0",
 		"@sveltejs/adapter-auto": "^2.0.0",
 		"@sveltejs/adapter-static": "^2.0.2",
 		"@sveltejs/kit": "^1.20.4",

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -123,3 +123,8 @@ body {
 		@apply font-normal;
 	}
 }
+
+#page {
+	/* Temporary workaround until Skeleton AppShell scrollbarGutter prop works */
+	scrollbar-gutter: stable both-edges;
+}

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -127,4 +127,13 @@ body {
 #page {
 	/* Temporary workaround until Skeleton AppShell scrollbarGutter prop works */
 	scrollbar-gutter: stable both-edges;
+
+	/* This is a less-temporary workaround to animate scrolling */
+	scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion) {
+	#page {
+		scroll-behavior: auto;
+	}
 }

--- a/src/lib/Drawer.svelte
+++ b/src/lib/Drawer.svelte
@@ -58,7 +58,7 @@
 	</nav>
 </Drawer>
 
-<style>
+<style lang="postcss">
 	.nav-anchor {
 		@apply no-underline text-token;
 		border-radius: var(--theme-rounded-base);

--- a/src/lib/Drawer.svelte
+++ b/src/lib/Drawer.svelte
@@ -19,7 +19,11 @@
 
 <svelte:window bind:innerWidth />
 
-<Drawer position="right" width="w-[280px] md:w-[480px]">
+<Drawer
+	position="right"
+	width="w-[280px] md:w-[480px]"
+	border="border-l border-r border-surface-300-600-token"
+>
 	<div class="px-2 flex justify-between flex-row">
 		<div />
 		<button class="close-btn hover:bg-primary-hover-token" on:click={drawerClose}>

--- a/src/lib/Drawer.svelte
+++ b/src/lib/Drawer.svelte
@@ -58,7 +58,7 @@
 	</nav>
 </Drawer>
 
-<style lang="postcss">
+<style>
 	.nav-anchor {
 		@apply no-underline text-token;
 		border-radius: var(--theme-rounded-base);

--- a/src/lib/Footer.svelte
+++ b/src/lib/Footer.svelte
@@ -1,5 +1,5 @@
 <footer
-	class="text-center box-border bg-surface-100-800-token w-full border-t border-surface-300-600-token print:hidden"
+	class="text-center box-border bg-surface-100-800-token w-full border-t border-l border-r border-surface-300-600-token print:hidden"
 >
 	<div class="p-4 px-2 mx-auto my-0 w-auto max-w-5xl">
 		<p>This is the footer.</p>

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div class="print:hidden">
-	<AppBar padding="px-2 py-0" border="border-b border-surface-300-600-token">
+	<AppBar padding="px-2 py-0" border="border-b border-l border-r border-surface-300-600-token">
 		<svelte:fragment slot="lead">
 			<Logo />
 		</svelte:fragment>

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -48,7 +48,7 @@
 	</AppBar>
 </div>
 
-<style lang="postcss">
+<style>
 	.nav-anchor {
 		@apply p-3 m-2 text-lg no-underline text-token;
 		border-radius: var(--theme-rounded-base);

--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -48,7 +48,7 @@
 	</AppBar>
 </div>
 
-<style>
+<style lang="postcss">
 	.nav-anchor {
 		@apply p-3 m-2 text-lg no-underline text-token;
 		border-radius: var(--theme-rounded-base);

--- a/src/lib/Logo.svelte
+++ b/src/lib/Logo.svelte
@@ -18,7 +18,7 @@
 	<span class="logo-txt">Petal Quest</span>
 </a>
 
-<style>
+<style lang="postcss">
 	.logo-anchor {
 		@apply flex items-center no-underline text-token p-2 m-1;
 		border-radius: var(--theme-rounded-base);

--- a/src/lib/Logo.svelte
+++ b/src/lib/Logo.svelte
@@ -18,7 +18,7 @@
 	<span class="logo-txt">Petal Quest</span>
 </a>
 
-<style lang="postcss">
+<style>
 	.logo-anchor {
 		@apply flex items-center no-underline text-token p-2 m-1;
 		border-radius: var(--theme-rounded-base);

--- a/src/lib/PageMeta.svelte
+++ b/src/lib/PageMeta.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	export let title: string;
-	export let type: string = 'website';
+	export let type = 'website';
 	export let description: string;
 	export let url: string;
-	// export let image: string = 'preview.png';
+	// export let image = 'preview.png';
 </script>
 
 <svelte:head>

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -33,9 +33,17 @@
 	};
 
 	// Builder State Management
+	function scrollToTop() {
+		const elemPage = document.querySelector('#page');
+		if (elemPage !== null) {
+			elemPage.scrollTop = 0;
+		}
+	}
+
 	function transition(): void {
 		currentDragonConfig.transition();
 		if ($nextBuilderState !== undefined) {
+			scrollToTop();
 			$lastBuilderState = $currentBuilderState;
 			$currentBuilderState = $nextBuilderState;
 			$nextBuilderState = undefined;

--- a/src/lib/dragon/DragonConfigPreview.svelte
+++ b/src/lib/dragon/DragonConfigPreview.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
+	import { page } from '$app/stores';
 	import { type DragonConfig, RGBToRGBA } from '.';
-	import { currentDragonConfig } from './builder-states';
+	import { currentDragonConfig, nextBuilderState } from './builder-states';
 
 	const dispatch = createEventDispatcher<{ clickDelete: DragonConfig }>();
 
@@ -27,7 +28,12 @@
 			<button
 				class="daisy-btn daisy-btn-neutral text-white"
 				on:click={() => {
-					$currentDragonConfig = config;
+					if (`?${config.toString()}` === $page.url.search) {
+						// no change is being made, so let's just go to DISPLAY
+						$nextBuilderState = 'DISPLAY';
+					} else {
+						$currentDragonConfig = config;
+					}
 				}}
 			>
 				Rebuild Dragon

--- a/src/lib/dragon/DragonContainer.svelte
+++ b/src/lib/dragon/DragonContainer.svelte
@@ -50,7 +50,7 @@
 	<div class="dragon-container-bot-edge" />
 </div>
 
-<style lang="postcss">
+<style>
 	.dragon-container {
 		@apply bg-neutral-200 text-black transition-all;
 		--y-edge-height: 4px;

--- a/src/lib/dragon/DragonContainer.svelte
+++ b/src/lib/dragon/DragonContainer.svelte
@@ -50,7 +50,7 @@
 	<div class="dragon-container-bot-edge" />
 </div>
 
-<style>
+<style lang="postcss">
 	.dragon-container {
 		@apply bg-neutral-200 text-black transition-all;
 		--y-edge-height: 4px;

--- a/src/lib/dragon/DragonContainer.svelte
+++ b/src/lib/dragon/DragonContainer.svelte
@@ -8,7 +8,7 @@
 	const iColorNext = () => {
 		iColor = (iColor + 1) % COLORS.length;
 	};
-	let colorInterval: NodeJS.Timeout;
+	let colorInterval: ReturnType<typeof setInterval>;
 	$: if (config === undefined) {
 		colorInterval = setInterval(iColorNext, 1000);
 	} else {
@@ -22,7 +22,7 @@
 	}
 
 	let innerClientHeight: number;
-	const minHeight: number = 300;
+	const minHeight = 300;
 	let outerWrapperHeight: number;
 	$: if (innerClientHeight < minHeight) {
 		outerWrapperHeight = minHeight;

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -132,7 +132,7 @@
 	{/if}
 </div>
 
-<style lang="postcss">
+<style>
 	.outer-wrapper {
 		@apply overflow-hidden;
 		height: var(--outer-wrapper-height);

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 
 	import { currentDragonConfig, nextBuilderState } from '.';
 	import { DEFAULT_PRONOUNS, DragonConfig } from '..';
@@ -104,10 +105,7 @@
 		class="daisy-btn daisy-btn-neutral m-2"
 		on:click={() => {
 			editedConfig.cleanup();
-			if (
-				$currentDragonConfig !== undefined &&
-				$currentDragonConfig.toString() === editedConfig.toString()
-			) {
+			if (`?${editedConfig.toString()}` === $page.url.search) {
 				// no change is being made, so let's just go to DISPLAY
 				$nextBuilderState = 'DISPLAY';
 			} else {

--- a/src/lib/dragon/builder-states/BuilderEdit.svelte
+++ b/src/lib/dragon/builder-states/BuilderEdit.svelte
@@ -132,7 +132,7 @@
 	{/if}
 </div>
 
-<style>
+<style lang="postcss">
 	.outer-wrapper {
 		@apply overflow-hidden;
 		height: var(--outer-wrapper-height);

--- a/src/lib/dragon/builder-states/BuilderHistory.svelte
+++ b/src/lib/dragon/builder-states/BuilderHistory.svelte
@@ -113,7 +113,7 @@
 <div class="flex flex-col items-center">
 	{#if historyPagesNeeded > 1}
 		<div class="daisy-join m-2">
-			{#each Array(historyPagesNeeded) as _, index (index)}
+			{#each [...Array(historyPagesNeeded).keys()] as index (index)}
 				<button
 					class="daisy-join-item daisy-btn daisy-btn-outline"
 					class:daisy-btn-active={index === currentHistoryPage}

--- a/src/lib/dragon/builder-states/BuilderHistory.svelte
+++ b/src/lib/dragon/builder-states/BuilderHistory.svelte
@@ -170,7 +170,7 @@
 	{/if}
 </div>
 
-<style lang="postcss">
+<style>
 	.outer-wrapper {
 		@apply overflow-hidden;
 		height: var(--outer-wrapper-height);

--- a/src/lib/dragon/builder-states/BuilderHistory.svelte
+++ b/src/lib/dragon/builder-states/BuilderHistory.svelte
@@ -170,7 +170,7 @@
 	{/if}
 </div>
 
-<style>
+<style lang="postcss">
 	.outer-wrapper {
 		@apply overflow-hidden;
 		height: var(--outer-wrapper-height);

--- a/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionBasics.svelte
@@ -109,6 +109,7 @@
 		<option value="she-her">She/Her</option>
 		<option value="he-him">He/Him</option>
 		<option value="they-them">They/Them</option>
+		<option value="ey-em">Ey/Em</option>
 		<option value="none">None</option>
 		<option value="custom">Custom</option>
 	</select>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { DragonConfig } from '$lib/dragon';
+	import { type DragonConfig, maxHPMin, maxHPMax } from '$lib/dragon';
 
 	export let config: DragonConfig;
 </script>
@@ -16,8 +16,8 @@
 		name="maxHP"
 		id="maxHP"
 		data-1p-ignore
-		min={1}
-		max={9999}
+		min={maxHPMin}
+		max={maxHPMax}
 		step={1}
 	/>
 </div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-	import { type DragonConfig, maxHPMin, maxHPMax } from '$lib/dragon';
+	import {
+		type DragonConfig,
+		maxHPMin,
+		maxHPMax,
+		numberOfHitDiceMin,
+		numberOfHitDiceMax,
+		abilityMin,
+		abilityMax
+	} from '$lib/dragon';
 
 	export let config: DragonConfig;
 </script>
@@ -18,6 +26,125 @@
 		data-1p-ignore
 		min={maxHPMin}
 		max={maxHPMax}
+		step={1}
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="numberOfHitDice">
+		<span class="daisy-label-text">Number of Hit Dice</span>
+	</label>
+	<input
+		type="number"
+		bind:value={config.numberOfHitDice}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="numberOfHitDice"
+		id="numberOfHitDice"
+		data-1p-ignore
+		min={numberOfHitDiceMin}
+		max={numberOfHitDiceMax}
+		step={1}
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="strength">
+		<span class="daisy-label-text">Strength</span>
+	</label>
+	<input
+		type="number"
+		bind:value={config.strength}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="strength"
+		id="strength"
+		data-1p-ignore
+		min={abilityMin}
+		max={abilityMax}
+		step={1}
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="dexterity">
+		<span class="daisy-label-text">Dexterity</span>
+	</label>
+	<input
+		type="number"
+		bind:value={config.dexterity}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="dexterity"
+		id="dexterity"
+		data-1p-ignore
+		min={abilityMin}
+		max={abilityMax}
+		step={1}
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="constitution">
+		<span class="daisy-label-text">Constitution</span>
+	</label>
+	<input
+		type="number"
+		bind:value={config.constitution}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="constitution"
+		id="constitution"
+		data-1p-ignore
+		min={abilityMin}
+		max={abilityMax}
+		step={1}
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="intelligence">
+		<span class="daisy-label-text">Intelligence</span>
+	</label>
+	<input
+		type="number"
+		bind:value={config.intelligence}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="intelligence"
+		id="intelligence"
+		data-1p-ignore
+		min={abilityMin}
+		max={abilityMax}
+		step={1}
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="wisdom">
+		<span class="daisy-label-text">Wisdom</span>
+	</label>
+	<input
+		type="number"
+		bind:value={config.wisdom}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="wisdom"
+		id="wisdom"
+		data-1p-ignore
+		min={abilityMin}
+		max={abilityMax}
+		step={1}
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="charisma">
+		<span class="daisy-label-text">Charisma</span>
+	</label>
+	<input
+		type="number"
+		bind:value={config.charisma}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="charisma"
+		id="charisma"
+		data-1p-ignore
+		min={abilityMin}
+		max={abilityMax}
 		step={1}
 	/>
 </div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionHPAbilities.svelte
@@ -4,4 +4,20 @@
 	export let config: DragonConfig;
 </script>
 
-<div>Coming soon!</div>
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="maxHP">
+		<span class="daisy-label-text">Maximum Hit Points</span>
+	</label>
+	<input
+		type="number"
+		bind:value={config.maxHP}
+		placeholder={'Defaults to expected value from Hit Dice'}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="maxHP"
+		id="maxHP"
+		data-1p-ignore
+		min={1}
+		max={9999}
+		step={1}
+	/>
+</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSpells.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSpells.svelte
@@ -4,4 +4,4 @@
 	export let config: DragonConfig;
 </script>
 
-<div>Coming soon!</div>
+<div>Coming soon! This printout is here to quiet a vite warning: {config}</div>

--- a/src/lib/dragon/builder-states/edit-form/FormSectionSpells.svelte
+++ b/src/lib/dragon/builder-states/edit-form/FormSectionSpells.svelte
@@ -4,4 +4,67 @@
 	export let config: DragonConfig;
 </script>
 
-<div>Coming soon! This printout is here to quiet a vite warning: {config}</div>
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="spellcasting">
+		<span class="daisy-label-text">Innate Spellcasting</span>
+	</label>
+	<select
+		bind:value={config.spellcasting}
+		class="daisy-select daisy-select-bordered bg-white"
+		name="spellcasting"
+		id="spellcasting"
+	>
+		<option value={undefined}>Default spellcasting enabled</option>
+		<option value="off">Innate Spellcasting disabled</option>
+		<option value="onlyAtWill">Only at-will spells enabled</option>
+		<option value="onlyDaily">Only 1/day spells enabled</option>
+	</select>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="atWillSpells">
+		<span class="daisy-label-text">At-Will Spells</span>
+	</label>
+	<input
+		type="text"
+		bind:value={config.atWillSpells}
+		placeholder={'Defaults to typical cantrip'}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="atWillSpells"
+		id="atWillSpells"
+		data-1p-ignore
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="dailySpells">
+		<span class="daisy-label-text">1/Day Spells</span>
+	</label>
+	<input
+		type="text"
+		bind:value={config.dailySpells}
+		placeholder={'Defaults to typical spells'}
+		class="daisy-input daisy-input-bordered bg-white"
+		name="dailySpells"
+		id="dailySpells"
+		data-1p-ignore
+	/>
+</div>
+
+<div class="daisy-form-control w-full max-w-sm m-1">
+	<label class="daisy-label" for="displaySpellStats">
+		<span class="daisy-label-text">Display Spell Attack and Save DC</span>
+	</label>
+	<select
+		bind:value={config.displaySpellStats}
+		class="daisy-select daisy-select-bordered bg-white"
+		name="displaySpellStats"
+		id="displaySpellStats"
+	>
+		<option value={undefined}>Default (Displays if relevant for typical spells)</option>
+		<option value="neither">Display neither</option>
+		<option value="attack">Display spell attack</option>
+		<option value="saveDC">Display spell save DC</option>
+		<option value="both">Display both</option>
+	</select>
+</div>

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -79,12 +79,9 @@ export class DragonStats {
 		this.wis = scoreToMod(this.wisdom);
 		this.cha = scoreToMod(this.charisma);
 
-		this.expectedHitPoints = expectedDiceResult(
-			this.numberOfHitDice,
-			this.hitDie,
-			this.numberOfHitDice * this.con,
-			1
-		);
+		this.expectedHitPoints =
+			this.#config.maxHP ??
+			expectedDiceResult(this.numberOfHitDice, this.hitDie, this.numberOfHitDice * this.con, 1);
 
 		this.immunity = this.#vals.immunity;
 		this.additionalImmunities = this.#vals.additionalImmunities;

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -347,7 +347,10 @@ export class DragonStats {
 
 	#getCantrips(): string[] {
 		let cantrips: string[] = [];
-		const rawCantrips = this.#vals.rawCantrip;
+		if (this.#config.spellcasting === 'off' || this.#config.spellcasting === 'onlyDaily') {
+			return cantrips; // return an empty array
+		}
+		const rawCantrips = this.#config.atWillSpells ?? this.#vals.rawCantrip;
 		if (rawCantrips.length > 0) {
 			cantrips = rawCantrips.split(spellcastingCommaRegex);
 		}
@@ -356,7 +359,10 @@ export class DragonStats {
 
 	#getSpells(): string[] {
 		let spells: string[] = [];
-		const rawSpells = this.#vals.rawSpells;
+		if (this.#config.spellcasting === 'off' || this.#config.spellcasting === 'onlyAtWill') {
+			return spells; // return an empty array
+		}
+		const rawSpells = this.#config.dailySpells ?? this.#vals.rawSpells;
 		if (rawSpells.length > 0) {
 			spells = rawSpells.split(spellcastingCommaRegex);
 		}
@@ -364,17 +370,29 @@ export class DragonStats {
 	}
 
 	#getSpellcastingDisplayAttack(): boolean {
-		return (
-			(this.cantrips.length > 0 && this.#vals.atWillSpellsHaveAttack > 0) ||
-			(this.spells.length > 0 && this.#vals.oncePerDaySpellsHaveAttack > 0)
-		);
+		if (this.#config.displaySpellStats !== undefined) {
+			return (
+				this.#config.displaySpellStats === 'attack' || this.#config.displaySpellStats === 'both'
+			);
+		} else {
+			return (
+				(this.cantrips.length > 0 && this.#vals.atWillSpellsHaveAttack > 0) ||
+				(this.spells.length > 0 && this.#vals.oncePerDaySpellsHaveAttack > 0)
+			);
+		}
 	}
 
 	#getSpellcastingDisplaySave(): boolean {
-		return (
-			(this.cantrips.length > 0 && this.#vals.atWillSpellsHaveSave > 0) ||
-			(this.spells.length > 0 && this.#vals.oncePerDaySpellsHaveSave > 0)
-		);
+		if (this.#config.displaySpellStats !== undefined) {
+			return (
+				this.#config.displaySpellStats === 'saveDC' || this.#config.displaySpellStats === 'both'
+			);
+		} else {
+			return (
+				(this.cantrips.length > 0 && this.#vals.atWillSpellsHaveSave > 0) ||
+				(this.spells.length > 0 && this.#vals.oncePerDaySpellsHaveSave > 0)
+			);
+		}
 	}
 
 	readonly #config: DragonConfig;

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -3,11 +3,16 @@ import {
 	COLOR_TO_ALIGNMENT,
 	AGE_TO_SIZE,
 	SIZE_TO_HIT_DIE,
+	ABILITIES,
 	SKILLS,
 	DEFAULT_PRONOUNS,
 	BASIC_PRONOUN_CONFIGS,
 	maxHPMin,
 	maxHPMax,
+	numberOfHitDiceMin,
+	numberOfHitDiceMax,
+	abilityMin,
+	abilityMax,
 	scoreToMod,
 	numberWithSign,
 	expectedDiceResult,
@@ -57,7 +62,7 @@ export class DragonStats {
 
 		this.size = AGE_TO_SIZE[this.age];
 		this.ac = this.#vals.ac;
-		this.numberOfHitDice = this.#vals.numberOfHitDice;
+		this.numberOfHitDice = this.#getNumberOfHitDice();
 		this.hitDie = SIZE_TO_HIT_DIE[this.size];
 
 		this.speed = this.#vals.walkingSpeed;
@@ -67,12 +72,12 @@ export class DragonStats {
 		this.swimSpeed = this.#vals.swimSpeed;
 		this.speeds = this.#getSpeeds();
 
-		this.strength = this.#vals.strength;
-		this.dexterity = this.#vals.dexterity;
-		this.constitution = this.#vals.constitution;
-		this.intelligence = this.#vals.intelligence;
-		this.wisdom = this.#vals.wisdom;
-		this.charisma = this.#vals.charisma;
+		this.strength = this.#getAbilityScore('strength');
+		this.dexterity = this.#getAbilityScore('dexterity');
+		this.constitution = this.#getAbilityScore('constitution');
+		this.intelligence = this.#getAbilityScore('intelligence');
+		this.wisdom = this.#getAbilityScore('wisdom');
+		this.charisma = this.#getAbilityScore('charisma');
 
 		this.str = scoreToMod(this.strength);
 		this.dex = scoreToMod(this.dexterity);
@@ -251,6 +256,35 @@ export class DragonStats {
 			return customPronounsConfig;
 		} else {
 			return BASIC_PRONOUN_CONFIGS[this.#config.pronouns];
+		}
+	}
+
+	#getNumberOfHitDice(): number {
+		if (
+			this.#config.numberOfHitDice !== undefined &&
+			this.#config.numberOfHitDice !== null &&
+			!Number.isNaN(this.#config.numberOfHitDice) &&
+			this.#config.numberOfHitDice >= numberOfHitDiceMin &&
+			this.#config.numberOfHitDice <= numberOfHitDiceMax
+		) {
+			return Math.floor(this.#config.numberOfHitDice);
+		} else {
+			return this.#vals.numberOfHitDice;
+		}
+	}
+
+	#getAbilityScore(ability: (typeof ABILITIES)[number][0]): number {
+		const abilityScore = this.#config[ability];
+		if (
+			abilityScore !== undefined &&
+			abilityScore !== null &&
+			!Number.isNaN(abilityScore) &&
+			abilityScore >= abilityMin &&
+			abilityScore <= abilityMax
+		) {
+			return Math.floor(abilityScore);
+		} else {
+			return this.#vals[ability];
 		}
 	}
 

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -258,9 +258,11 @@ export class DragonStats {
 		if (
 			this.#config.maxHP !== undefined &&
 			this.#config.maxHP !== null &&
-			!Number.isNaN(this.#config.maxHP)
+			!Number.isNaN(this.#config.maxHP) &&
+			this.#config.maxHP >= maxHPMin &&
+			this.#config.maxHP <= maxHPMax
 		) {
-			return Math.max(maxHPMin, Math.min(maxHPMax, this.#config.maxHP));
+			return Math.floor(this.#config.maxHP);
 		} else {
 			return expectedDiceResult(
 				this.numberOfHitDice,

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -6,6 +6,8 @@ import {
 	SKILLS,
 	DEFAULT_PRONOUNS,
 	BASIC_PRONOUN_CONFIGS,
+	maxHPMin,
+	maxHPMax,
 	scoreToMod,
 	numberWithSign,
 	expectedDiceResult,
@@ -79,9 +81,7 @@ export class DragonStats {
 		this.wis = scoreToMod(this.wisdom);
 		this.cha = scoreToMod(this.charisma);
 
-		this.expectedHitPoints =
-			this.#config.maxHP ??
-			expectedDiceResult(this.numberOfHitDice, this.hitDie, this.numberOfHitDice * this.con, 1);
+		this.expectedHitPoints = this.#getExpectedHitPoints();
 
 		this.immunity = this.#vals.immunity;
 		this.additionalImmunities = this.#vals.additionalImmunities;
@@ -251,6 +251,23 @@ export class DragonStats {
 			return customPronounsConfig;
 		} else {
 			return BASIC_PRONOUN_CONFIGS[this.#config.pronouns];
+		}
+	}
+
+	#getExpectedHitPoints(): number {
+		if (
+			this.#config.maxHP !== undefined &&
+			this.#config.maxHP !== null &&
+			!Number.isNaN(this.#config.maxHP)
+		) {
+			return Math.max(maxHPMin, Math.min(maxHPMax, this.#config.maxHP));
+		} else {
+			return expectedDiceResult(
+				this.numberOfHitDice,
+				this.hitDie,
+				this.numberOfHitDice * this.con,
+				1
+			);
 		}
 	}
 

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -378,6 +378,12 @@ export const maxHPMax = 9999;
 export const numberOfHitDiceMin = 1;
 export const numberOfHitDiceMax = 99;
 
+export const SPELLCASTING_CONFIG_OPTIONS = ['off', 'onlyAtWill', 'onlyDaily'] as const;
+export type SpellcastingConfig = (typeof SPELLCASTING_CONFIG_OPTIONS)[number];
+
+export const DISPLAY_SPELL_STATS_OPTIONS = ['both', 'attack', 'saveDC', 'neither'] as const;
+export type DisplaySpellStats = (typeof DISPLAY_SPELL_STATS_OPTIONS)[number];
+
 export class DragonConfig {
 	age: Age = 'wyrmling';
 	color: Color = 'red';
@@ -417,6 +423,11 @@ export class DragonConfig {
 	skillSleightOfHand?: ProficiencyLevel;
 	skillStealth?: ProficiencyLevel;
 	skillSurvival?: ProficiencyLevel;
+
+	spellcasting?: SpellcastingConfig;
+	atWillSpells?: string;
+	dailySpells?: string;
+	displaySpellStats?: DisplaySpellStats;
 
 	/**
 	 * Returns the title for this DragonConfig.
@@ -516,6 +527,13 @@ export class DragonConfig {
 				delete this[abilityTuple[0]];
 			}
 		}
+
+		if (this.atWillSpells === '') {
+			delete this.atWillSpells;
+		}
+		if (this.dailySpells === '') {
+			delete this.dailySpells;
+		}
 	}
 
 	/**
@@ -594,6 +612,19 @@ export class DragonConfig {
 			}
 		}
 
+		if (this.spellcasting !== undefined) {
+			output.set('spellcasting', this.spellcasting);
+		}
+		if (this.atWillSpells !== undefined) {
+			output.set('atWillSpells', this.atWillSpells);
+		}
+		if (this.dailySpells !== undefined) {
+			output.set('dailySpells', this.dailySpells);
+		}
+		if (this.displaySpellStats !== undefined) {
+			output.set('displaySpellStats', this.displaySpellStats);
+		}
+
 		return output;
 	}
 
@@ -660,6 +691,11 @@ export class DragonConfig {
 
 		this.#setSkillsFromURLSearchParams(params);
 
+		this.#setSpellcastingFromURLSearchParams(params);
+		this.#setAtWillSpellsFromURLSearchParams(params);
+		this.#setDailySpellsFromURLSearchParams(params);
+		this.#setDisplaySpellStatsFromURLSearchParams(params);
+
 		return true;
 	}
 
@@ -680,7 +716,7 @@ export class DragonConfig {
 		if (paramsPronounsVal !== null) {
 			// we have to check several options here to maintain backwards compatibility
 			if (paramsPronounsVal === DEFAULT_PRONOUNS || paramsPronounsVal === 'default') {
-				this.pronouns = undefined;
+				delete this.pronouns;
 			} else if (paramsPronounsVal === 'it-its' || paramsPronounsVal === 'neutral') {
 				this.pronouns = 'it-its';
 			} else if (paramsPronounsVal === 'she-her' || paramsPronounsVal === 'feminine') {
@@ -705,7 +741,7 @@ export class DragonConfig {
 				return; // don't check the URL for custom pronouns
 			} else {
 				console.log(`Unable to parse URL pronouns value of ${paramsPronounsVal}`);
-				this.pronouns = undefined;
+				delete this.pronouns;
 			}
 		}
 
@@ -823,6 +859,74 @@ export class DragonConfig {
 				) {
 					this[skill.key] = paramsSkillFloat;
 				}
+			}
+		}
+	}
+
+	#setSpellcastingFromURLSearchParams(params: URLSearchParams) {
+		const keys = ['spellcasting', 'spellstate'] as const;
+		for (const key of keys) {
+			const paramsKeyVal = params.get(key);
+			if (paramsKeyVal !== null) {
+				if (paramsKeyVal === 'default') {
+					delete this.spellcasting;
+				} else if (paramsKeyVal === 'off') {
+					this.spellcasting = 'off';
+				} else if (paramsKeyVal === 'onlyAtWill' || paramsKeyVal === 'onlyatwill') {
+					this.spellcasting = 'onlyAtWill';
+				} else if (paramsKeyVal === 'onlyDaily' || paramsKeyVal === 'noatwill') {
+					this.spellcasting = 'onlyDaily';
+				} else {
+					console.log(`Unable to parse URL spellcasting value of ${paramsKeyVal}`);
+					delete this.spellcasting;
+				}
+				return;
+			}
+		}
+	}
+
+	#setAtWillSpellsFromURLSearchParams(params: URLSearchParams) {
+		const keys = ['atWillSpells', 'cantripoverride'] as const;
+		for (const key of keys) {
+			const paramsKeyVal = params.get(key);
+			if (paramsKeyVal !== null) {
+				this.atWillSpells = paramsKeyVal;
+				return;
+			}
+		}
+	}
+
+	#setDailySpellsFromURLSearchParams(params: URLSearchParams) {
+		const keys = ['dailySpells', 'spellsoverride'] as const;
+		for (const key of keys) {
+			const paramsKeyVal = params.get(key);
+			if (paramsKeyVal !== null) {
+				this.dailySpells = paramsKeyVal;
+				return;
+			}
+		}
+	}
+
+	#setDisplaySpellStatsFromURLSearchParams(params: URLSearchParams) {
+		const keys = ['displaySpellStats', 'spelldescription'] as const;
+		for (const key of keys) {
+			const paramsKeyVal = params.get(key);
+			if (paramsKeyVal !== null) {
+				if (paramsKeyVal === 'default') {
+					delete this.displaySpellStats;
+				} else if (paramsKeyVal === 'neither') {
+					this.displaySpellStats = 'neither';
+				} else if (paramsKeyVal === 'both') {
+					this.displaySpellStats = 'both';
+				} else if (paramsKeyVal === 'attack') {
+					this.displaySpellStats = 'attack';
+				} else if (paramsKeyVal === 'saveDC' || paramsKeyVal === 'dc') {
+					this.displaySpellStats = 'saveDC';
+				} else {
+					console.log(`Unable to parse URL displaySpellStats value of ${paramsKeyVal}`);
+					delete this.displaySpellStats;
+				}
+				return;
 			}
 		}
 	}

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -472,10 +472,14 @@ export class DragonConfig {
 			delete this.pronounsConfig;
 		}
 
-		if (this.maxHP !== undefined && this.maxHP !== null) {
-			if (Number.isNaN(this.maxHP)) {
-				delete this.maxHP;
-			}
+		if (
+			this.maxHP !== undefined &&
+			(this.maxHP === null ||
+				Number.isNaN(this.maxHP) ||
+				this.maxHP < maxHPMin ||
+				this.maxHP > maxHPMax)
+		) {
+			delete this.maxHP;
 		}
 	}
 
@@ -516,8 +520,14 @@ export class DragonConfig {
 			output.set('pronounPossessiveAdjective', this.pronounsConfig.possessiveAdjective);
 		}
 
-		if (this.maxHP !== undefined && this.maxHP !== null && !Number.isNaN(this.maxHP)) {
-			output.set('maxHP', Math.max(maxHPMin, Math.min(maxHPMax, this.maxHP)).toString());
+		if (
+			this.maxHP !== undefined &&
+			this.maxHP !== null &&
+			!Number.isNaN(this.maxHP) &&
+			this.maxHP >= maxHPMin &&
+			this.maxHP <= maxHPMax
+		) {
+			output.set('maxHP', Math.floor(this.maxHP).toString());
 		}
 
 		for (const skill of SKILLS) {
@@ -696,8 +706,8 @@ export class DragonConfig {
 			const paramsKeyVal = params.get(key);
 			if (paramsKeyVal !== null) {
 				const paramsKeyInt = parseInt(paramsKeyVal);
-				if (!Number.isNaN(paramsKeyInt)) {
-					this.maxHP = Math.max(maxHPMin, Math.min(maxHPMax, paramsKeyInt));
+				if (!Number.isNaN(paramsKeyInt) && paramsKeyInt >= maxHPMin && paramsKeyInt <= maxHPMax) {
+					this.maxHP = paramsKeyInt;
 					return;
 				}
 			}

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -146,6 +146,9 @@ export const ABILITIES = [
 	['charisma', 'cha']
 ] as const;
 
+export const abilityMin = 1;
+export const abilityMax = 30;
+
 const standardDefaultSkillDescription = 'Varies with age and color';
 export const SKILLS = [
 	{
@@ -372,6 +375,8 @@ export const BASIC_PRONOUN_CONFIGS: {
 
 export const maxHPMin = 1;
 export const maxHPMax = 9999;
+export const numberOfHitDiceMin = 1;
+export const numberOfHitDiceMax = 99;
 
 export class DragonConfig {
 	age: Age = 'wyrmling';
@@ -385,6 +390,14 @@ export class DragonConfig {
 	pronounsConfig?: PronounsConfig; // only needed if using custom pronouns
 
 	maxHP?: number | null;
+	numberOfHitDice?: number | null;
+
+	strength?: number | null;
+	dexterity?: number | null;
+	constitution?: number | null;
+	intelligence?: number | null;
+	wisdom?: number | null;
+	charisma?: number | null;
 
 	skillAcrobatics?: ProficiencyLevel;
 	skillAnimalHandling?: ProficiencyLevel;
@@ -481,6 +494,28 @@ export class DragonConfig {
 		) {
 			delete this.maxHP;
 		}
+		if (
+			this.numberOfHitDice !== undefined &&
+			(this.numberOfHitDice === null ||
+				Number.isNaN(this.numberOfHitDice) ||
+				this.numberOfHitDice < numberOfHitDiceMin ||
+				this.numberOfHitDice > numberOfHitDiceMax)
+		) {
+			delete this.numberOfHitDice;
+		}
+
+		for (const abilityTuple of ABILITIES) {
+			const abilityScore = this[abilityTuple[0]];
+			if (
+				abilityScore !== undefined &&
+				(abilityScore === null ||
+					Number.isNaN(abilityScore) ||
+					abilityScore < abilityMin ||
+					abilityScore > abilityMax)
+			) {
+				delete this[abilityTuple[0]];
+			}
+		}
 	}
 
 	/**
@@ -528,6 +563,28 @@ export class DragonConfig {
 			this.maxHP <= maxHPMax
 		) {
 			output.set('maxHP', Math.floor(this.maxHP).toString());
+		}
+		if (
+			this.numberOfHitDice !== undefined &&
+			this.numberOfHitDice !== null &&
+			!Number.isNaN(this.numberOfHitDice) &&
+			this.numberOfHitDice >= numberOfHitDiceMin &&
+			this.numberOfHitDice <= numberOfHitDiceMax
+		) {
+			output.set('numberOfHitDice', Math.floor(this.numberOfHitDice).toString());
+		}
+
+		for (const abilityTuple of ABILITIES) {
+			const abilityScore = this[abilityTuple[0]];
+			if (
+				abilityScore !== undefined &&
+				abilityScore !== null &&
+				!Number.isNaN(abilityScore) &&
+				abilityScore >= abilityMin &&
+				abilityScore <= abilityMax
+			) {
+				output.set(abilityTuple[0], Math.floor(abilityScore).toString());
+			}
 		}
 
 		for (const skill of SKILLS) {
@@ -596,6 +653,10 @@ export class DragonConfig {
 		this.#setPronounsFromURLSearchParams(params);
 
 		this.#setMaxHPFromURLSearchParams(params);
+
+		this.#setNumberOfHitDiceFromURLSearchParams(params);
+
+		this.#setAbilitiesFromURLSearchParams(params);
 
 		this.#setSkillsFromURLSearchParams(params);
 
@@ -709,6 +770,41 @@ export class DragonConfig {
 				if (!Number.isNaN(paramsKeyInt) && paramsKeyInt >= maxHPMin && paramsKeyInt <= maxHPMax) {
 					this.maxHP = paramsKeyInt;
 					return;
+				}
+			}
+		}
+	}
+
+	#setNumberOfHitDiceFromURLSearchParams(params: URLSearchParams) {
+		const keys = ['numberOfHitDice'] as const;
+		for (const key of keys) {
+			const paramsKeyVal = params.get(key);
+			if (paramsKeyVal !== null) {
+				const paramsKeyInt = parseInt(paramsKeyVal);
+				if (
+					!Number.isNaN(paramsKeyInt) &&
+					paramsKeyInt >= numberOfHitDiceMin &&
+					paramsKeyInt <= numberOfHitDiceMax
+				) {
+					this.numberOfHitDice = paramsKeyInt;
+					return;
+				}
+			}
+		}
+	}
+
+	#setAbilitiesFromURLSearchParams(params: URLSearchParams) {
+		for (const abilityTuple of ABILITIES) {
+			const key = abilityTuple[0];
+			const paramsKeyVal = params.get(key);
+			if (paramsKeyVal !== null) {
+				const paramsKeyInt = parseInt(paramsKeyVal);
+				if (
+					!Number.isNaN(paramsKeyInt) &&
+					paramsKeyInt >= abilityMin &&
+					paramsKeyInt <= abilityMax
+				) {
+					this[key] = paramsKeyInt;
 				}
 			}
 		}

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -381,6 +381,8 @@ export class DragonConfig {
 	pronouns?: Pronouns;
 	pronounsConfig?: PronounsConfig; // only needed if using custom pronouns
 
+	maxHP?: number;
+
 	skillAcrobatics?: ProficiencyLevel;
 	skillAnimalHandling?: ProficiencyLevel;
 	skillArcana?: ProficiencyLevel;
@@ -466,6 +468,12 @@ export class DragonConfig {
 			// we only use the pronounsConfig if using custom pronouns
 			delete this.pronounsConfig;
 		}
+
+		if (this.maxHP !== undefined) {
+			if (!Number.isSafeInteger(this.maxHP)) {
+				delete this.maxHP;
+			}
+		}
 	}
 
 	/**
@@ -503,6 +511,10 @@ export class DragonConfig {
 			output.set('pronounNominative', this.pronounsConfig.nominative);
 			output.set('pronounObjective', this.pronounsConfig.objective);
 			output.set('pronounPossessiveAdjective', this.pronounsConfig.possessiveAdjective);
+		}
+
+		if (this.maxHP !== undefined) {
+			output.set('maxHP', this.#boundMaxHP(this.maxHP).toString());
 		}
 
 		for (const skill of SKILLS) {
@@ -569,6 +581,8 @@ export class DragonConfig {
 		}
 
 		this.#setPronounsFromURLSearchParams(params);
+
+		this.#setMaxHPFromURLSearchParams(params);
 
 		this.#setSkillsFromURLSearchParams(params);
 
@@ -670,6 +684,25 @@ export class DragonConfig {
 				possessiveAdjective: pronounPossessiveAdjective
 			};
 			this.pronounsConfig = customConfig;
+		}
+	}
+
+	#boundMaxHP(maxHP: number): number {
+		return (maxHP = Math.max(1, Math.min(9999, maxHP)));
+	}
+
+	#setMaxHPFromURLSearchParams(params: URLSearchParams) {
+		const keys = ['maxHP', 'hp-override'] as const;
+		for (const key of keys) {
+			const paramsKeyVal = params.get(key);
+			if (paramsKeyVal !== null) {
+				const paramsKeyInt = parseInt(paramsKeyVal);
+				if (!Number.isNaN(paramsKeyInt)) {
+					this.maxHP = paramsKeyInt;
+					this.maxHP = this.#boundMaxHP(this.maxHP);
+					return;
+				}
+			}
 		}
 	}
 

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -331,7 +331,7 @@ export function RGBToRGBA(rgb: RGB, a: number): string {
 	return `rgba(${rgb.substring(4, rgb.length - 1)}, ${a})`;
 }
 
-export const BASIC_PRONOUN_OPTIONS = ['it-its', 'she-her', 'he-him', 'they-them'] as const;
+export const BASIC_PRONOUN_OPTIONS = ['it-its', 'she-her', 'he-him', 'they-them', 'ey-em'] as const;
 export type BasicPronouns = (typeof BASIC_PRONOUN_OPTIONS)[number];
 export const DEFAULT_PRONOUNS = 'she-her'; // assumed to be of type BasicPronouns
 
@@ -370,6 +370,12 @@ export const BASIC_PRONOUN_CONFIGS: {
 		nominative: 'they',
 		objective: 'them',
 		possessiveAdjective: 'their'
+	},
+	'ey-em': {
+		plural: false,
+		nominative: 'ey',
+		objective: 'em',
+		possessiveAdjective: 'eir'
 	}
 } as const;
 
@@ -725,20 +731,12 @@ export class DragonConfig {
 				this.pronouns = 'he-him';
 			} else if (paramsPronounsVal === 'they-them' || paramsPronounsVal === 'singularthey') {
 				this.pronouns = 'they-them';
+			} else if (paramsPronounsVal === 'ey-em' || paramsPronounsVal === 'spivak') {
+				this.pronouns = 'ey-em';
 			} else if (paramsPronounsVal === 'none' || paramsPronounsVal === 'no-pronouns') {
 				this.pronouns = 'none';
 			} else if (paramsPronounsVal === 'custom' || paramsPronounsVal === 'custom-pronouns') {
 				this.pronouns = 'custom';
-			} else if (paramsPronounsVal === 'ey-em' || paramsPronounsVal === 'spivak') {
-				// we want to support these URL options, using them as custom pronouns
-				this.pronouns = 'custom';
-				this.pronounsConfig = {
-					plural: false,
-					nominative: 'ey',
-					objective: 'em',
-					possessiveAdjective: 'eir'
-				};
-				return; // don't check the URL for custom pronouns
 			} else {
 				console.log(`Unable to parse URL pronouns value of ${paramsPronounsVal}`);
 				delete this.pronouns;

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -370,6 +370,9 @@ export const BASIC_PRONOUN_CONFIGS: {
 	}
 } as const;
 
+export const maxHPMin = 1;
+export const maxHPMax = 9999;
+
 export class DragonConfig {
 	age: Age = 'wyrmling';
 	color: Color = 'red';
@@ -381,7 +384,7 @@ export class DragonConfig {
 	pronouns?: Pronouns;
 	pronounsConfig?: PronounsConfig; // only needed if using custom pronouns
 
-	maxHP?: number;
+	maxHP?: number | null;
 
 	skillAcrobatics?: ProficiencyLevel;
 	skillAnimalHandling?: ProficiencyLevel;
@@ -469,8 +472,8 @@ export class DragonConfig {
 			delete this.pronounsConfig;
 		}
 
-		if (this.maxHP !== undefined) {
-			if (!Number.isSafeInteger(this.maxHP)) {
+		if (this.maxHP !== undefined && this.maxHP !== null) {
+			if (Number.isNaN(this.maxHP)) {
 				delete this.maxHP;
 			}
 		}
@@ -513,8 +516,8 @@ export class DragonConfig {
 			output.set('pronounPossessiveAdjective', this.pronounsConfig.possessiveAdjective);
 		}
 
-		if (this.maxHP !== undefined) {
-			output.set('maxHP', this.#boundMaxHP(this.maxHP).toString());
+		if (this.maxHP !== undefined && this.maxHP !== null && !Number.isNaN(this.maxHP)) {
+			output.set('maxHP', Math.max(maxHPMin, Math.min(maxHPMax, this.maxHP)).toString());
 		}
 
 		for (const skill of SKILLS) {
@@ -687,10 +690,6 @@ export class DragonConfig {
 		}
 	}
 
-	#boundMaxHP(maxHP: number): number {
-		return (maxHP = Math.max(1, Math.min(9999, maxHP)));
-	}
-
 	#setMaxHPFromURLSearchParams(params: URLSearchParams) {
 		const keys = ['maxHP', 'hp-override'] as const;
 		for (const key of keys) {
@@ -698,8 +697,7 @@ export class DragonConfig {
 			if (paramsKeyVal !== null) {
 				const paramsKeyInt = parseInt(paramsKeyVal);
 				if (!Number.isNaN(paramsKeyInt)) {
-					this.maxHP = paramsKeyInt;
-					this.maxHP = this.#boundMaxHP(this.maxHP);
+					this.maxHP = Math.max(maxHPMin, Math.min(maxHPMax, paramsKeyInt));
 					return;
 				}
 			}

--- a/src/lib/dragon/stat-block/StatBlockDivider.svelte
+++ b/src/lib/dragon/stat-block/StatBlockDivider.svelte
@@ -2,8 +2,8 @@
 	import type { RGB } from '$lib/dragon';
 
 	export let color: RGB;
-	export let height: string = '1px';
-	export let classes: string = '';
+	export let height = '1px';
+	export let classes = '';
 </script>
 
 <div class="my-1 {classes}" style="height: {height};">

--- a/src/lib/modals/DragonShare.svelte
+++ b/src/lib/modals/DragonShare.svelte
@@ -1,7 +1,30 @@
 <script lang="ts">
 	// Props
 	/** Exposes parent props to this component. */
-	export let parent: any;
+	export let parent: {
+		position: string;
+		// ---
+		background: string;
+		width: string;
+		height: string;
+		padding: string;
+		spacing: string;
+		rounded: string;
+		shadow: string;
+		// ---
+		buttonNeutral: string;
+		buttonPositive: string;
+		buttonTextCancel: string;
+		buttonTextConfirm: string;
+		buttonTextSubmit: string;
+		// ---
+		regionBackdrop: string;
+		regionHeader: string;
+		regionBody: string;
+		regionFooter: string;
+		// ---
+		onClose: () => void;
+	};
 
 	// Stores
 	import { getModalStore, clipboard } from '@skeletonlabs/skeleton';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import '../app.postcss';
 
+	import { afterNavigate } from '$app/navigation';
+	import type { AfterNavigate } from '@sveltejs/kit';
+
 	import { initializeStores, type ModalComponent } from '@skeletonlabs/skeleton';
 	import { AppShell, Modal, Toast } from '@skeletonlabs/skeleton';
 	import DragonShare from '$lib/modals/DragonShare.svelte';
@@ -15,6 +18,17 @@
 			ref: DragonShare
 		}
 	};
+
+	afterNavigate((navigation: AfterNavigate) => {
+		const isNewPage: boolean =
+			navigation.from === null || navigation.to === null
+				? false
+				: navigation.from.route.id !== navigation.to.route.id;
+		const elemPage = document.querySelector('#page');
+		if (isNewPage && elemPage !== null) {
+			elemPage.scrollTop = 0;
+		}
+	});
 </script>
 
 <Toast transitionOutParams={{ duration: 50 }} buttonDismiss="btn btn-icon-sm variant-filled" />

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -46,7 +46,7 @@
 </p>
 <p><a href="/">Return to Home.</a></p>
 
-<style lang="postcss">
+<style>
 	.filler {
 		@apply text-4xl p-4;
 	}

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -46,7 +46,7 @@
 </p>
 <p><a href="/">Return to Home.</a></p>
 
-<style>
+<style lang="postcss">
 	.filler {
 		@apply text-4xl p-4;
 	}


### PR DESCRIPTION
## What's in this PR?
This PR contains the following changes:
- The "HP & Abilities" and "Spells" tabs on BuilderEdit are now complete!
  - This is a lot of new options. You can now set the following: Max Hit Points, Hit Dice, Ability Scores, and all features of Innate Spellcasting.
  - I added 'ey-em' as fully supported pronouns rather than half-assing support for them.
- I cleaned up some linting behavior and fixed some warnings.
- I updated Skeleton to use the new `scrollbarGutter` prop, but it doesn't work yet, so I added a workaround to effectively use it. I added an npm script to make it simpler to update Skeleton in the future.
- I updated some borders in response to the scrollbar-gutter changes.
- The website now scrolls to the top whenever you navigate to a new page or change the Dragon Builder state.
- I fixed a bug where rebuilding the current dragon from Builder History would add an entry to browser history. I also updated Builder Edit so that if the current URL is not the canonical URL for the current dragon, clicking "Update Dragon" without any edits will update the URL.

## 🐢
