### PR TITLE
Updated the AbbrButton to open a modal instead of a tooltip

### DIFF
--- a/src/lib/dragon/stat-block/AbbrButton.svelte
+++ b/src/lib/dragon/stat-block/AbbrButton.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
-	import { normalizeString } from '$lib/text-utils';
+	import { getModalStore, type ModalSettings } from '@skeletonlabs/skeleton';
 
-	export let title: string;
+	const modalStore = getModalStore();
+	const modalConfig: ModalSettings = {
+		type: 'component',
+		component: 'abbrModal'
+	};
 
-	let abbrID = `abbrevationDropdown__${normalizeString(title)}`;
+	export let abbreviation: string;
+	export let definition: string;
 
 	function handleClick() {
-		// no action required
+		modalConfig.value = { abbreviation, definition };
+		modalStore.trigger(modalConfig);
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
@@ -22,23 +28,11 @@
 	}
 </script>
 
-<div class="daisy-dropdown daisy-dropdown-hover">
-	<label for={abbrID}>
-		<span
-			role="button"
-			tabindex="0"
-			on:keydown={handleKeydown}
-			on:keyup={handleKeyup}
-			on:click={handleClick}
-			class="underline decoration-dotted"><slot /></span
-		>
-	</label>
-	<div
-		id={abbrID}
-		class="daisy-card daisy-compact daisy-dropdown-content z-[1] shadow bg-base-100 rounded-box border border-black min-w-[8rem]"
-	>
-		<div class="daisy-card-body">
-			<p class="font-normal not-italic">{title}</p>
-		</div>
-	</div>
-</div>
+<span
+	role="button"
+	tabindex="0"
+	on:keydown={handleKeydown}
+	on:keyup={handleKeyup}
+	on:click={handleClick}
+	class="underline">{abbreviation}</span
+>

--- a/src/lib/dragon/stat-block/AbbrButton.svelte
+++ b/src/lib/dragon/stat-block/AbbrButton.svelte
@@ -34,5 +34,5 @@
 	on:keydown={handleKeydown}
 	on:keyup={handleKeyup}
 	on:click={handleClick}
-	class="underline">{abbreviation}</span
+	class="underline print:no-underline">{abbreviation}</span
 >

--- a/src/lib/dragon/stat-block/UpcastAbbr.svelte
+++ b/src/lib/dragon/stat-block/UpcastAbbr.svelte
@@ -6,13 +6,12 @@
 	export let level: SpellLevel;
 
 	let maxLevelWithOrdinal = numberWithOrdinalSuffix(level);
+	let abbreviation = `Upcast to ${maxLevelWithOrdinal} Level`;
 	let affectedLevels =
 		level > 2 ? `1st through ${numberWithOrdinalSuffix(level - 1)} level` : '1st level';
-	let abbrTitle = `Spells of ${affectedLevels} are cast at ${maxLevelWithOrdinal} level.`;
+	let definition = `Spells of ${affectedLevels} are cast at ${maxLevelWithOrdinal} level.`;
 </script>
 
 {#if level > 1}
-	{' ('}<AbbrButton title={abbrTitle}>
-		<span class="italic">Upcast to {maxLevelWithOrdinal} Level</span>
-	</AbbrButton>{')'}
+	{' ('}<AbbrButton {abbreviation} {definition} />{')'}
 {/if}

--- a/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
+++ b/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { capitalizeFirstLetter } from '$lib/text-utils';
 	import type { DragonStats } from '$lib/dragon/dragon-stats';
-	import AbbrButton from '../AbbrButton.svelte';
 
 	export let dragon: DragonStats;
 

--- a/src/lib/dragon/stat-block/bonus-actions/BActionFrightfulFlare.svelte
+++ b/src/lib/dragon/stat-block/bonus-actions/BActionFrightfulFlare.svelte
@@ -4,17 +4,16 @@
 	import AbbrButton from '../AbbrButton.svelte';
 
 	export let dragon: DragonStats;
+
+	let abbreviation = '1/SR';
+	let definition = 'Recharges after a Short or Long Rest';
 </script>
 
 {#if dragon.hasFrightfulFlare}
 	<div class="dragon-action">
 		<p>
 			<i>
-				<b
-					>Frightful Flare (<AbbrButton title="Recharges after a Short or Long Rest"
-						><span class="italic">1/SR</span></AbbrButton
-					>).
-				</b>
+				<b>Frightful Flare (<AbbrButton {abbreviation} {definition} />). </b>
 			</i>
 			{dragon.nameUpper} unleashes {dragon.pronounPossessiveAdjective} inner light, maxing out {dragon.pronounPossessiveAdjective}
 			Variable Radiance to a radius of {dragon.prismaticRadianceRadius} feet. Each creature of {dragon.name}'s

--- a/src/lib/modals/AbbrModal.svelte
+++ b/src/lib/modals/AbbrModal.svelte
@@ -30,13 +30,13 @@
 	import { getModalStore } from '@skeletonlabs/skeleton';
 	const modalStore = getModalStore();
 
-	let abbrInfo: { abbr: string; title: string } = $modalStore[0].value;
+	let abbrInfo: { abbreviation: string; definition: string } = $modalStore[0].value;
 </script>
 
 {#if $modalStore[0]}
 	<div class="card p-4 w-modal shadow-xl space-y-4 overflow-x-clip">
-		<header class="text-2xl font-bold">{abbrInfo.abbr}</header>
-		<div>{abbrInfo.title}</div>
+		<header class="text-2xl font-bold">Abbreviation: {abbrInfo.abbreviation}</header>
+		<div>Definition: {abbrInfo.definition}</div>
 		<footer class="modal-footer {parent.regionFooter}">
 			<button class="btn {parent.buttonNeutral}" on:click={parent.onClose}> Close </button>
 		</footer>

--- a/src/lib/modals/AbbrModal.svelte
+++ b/src/lib/modals/AbbrModal.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	// Props
+	/** Exposes parent props to this component. */
+	export let parent: {
+		position: string;
+		// ---
+		background: string;
+		width: string;
+		height: string;
+		padding: string;
+		spacing: string;
+		rounded: string;
+		shadow: string;
+		// ---
+		buttonNeutral: string;
+		buttonPositive: string;
+		buttonTextCancel: string;
+		buttonTextConfirm: string;
+		buttonTextSubmit: string;
+		// ---
+		regionBackdrop: string;
+		regionHeader: string;
+		regionBody: string;
+		regionFooter: string;
+		// ---
+		onClose: () => void;
+	};
+
+	// Stores
+	import { getModalStore } from '@skeletonlabs/skeleton';
+	const modalStore = getModalStore();
+
+	let abbrInfo: { abbr: string; title: string } = $modalStore[0].value;
+</script>
+
+{#if $modalStore[0]}
+	<div class="card p-4 w-modal shadow-xl space-y-4 overflow-x-clip">
+		<header class="text-2xl font-bold">{abbrInfo.abbr}</header>
+		<div>{abbrInfo.title}</div>
+		<footer class="modal-footer {parent.regionFooter}">
+			<button class="btn {parent.buttonNeutral}" on:click={parent.onClose}> Close </button>
+		</footer>
+	</div>
+{/if}

--- a/src/lib/spells/SpellLink.svelte
+++ b/src/lib/spells/SpellLink.svelte
@@ -37,5 +37,5 @@
 	on:click={handleClick}
 	on:keydown={handleKeydown}
 	on:keyup={handleKeyup}
-	class="italic underline">{spellName}</span
+	class="italic underline print:no-underline">{spellName}</span
 >

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 
 	import { initializeStores, type ModalComponent } from '@skeletonlabs/skeleton';
 	import { AppShell, Modal, Toast } from '@skeletonlabs/skeleton';
+	import AbbrModal from '$lib/modals/AbbrModal.svelte';
 	import AddLocalSpell from '$lib/modals/AddLocalSpell.svelte';
 	import ManageLocalSpells from '$lib/modals/ManageLocalSpells.svelte';
 	import DragonShare from '$lib/modals/DragonShare.svelte';
@@ -17,6 +18,9 @@
 	initializeStores();
 
 	const modalComponentRegistry: Record<string, ModalComponent> = {
+		abbrModal: {
+			ref: AbbrModal
+		},
 		addLocalSpell: {
 			ref: AddLocalSpell
 		},


### PR DESCRIPTION
## What's in this PR?
I updated the AbbrButton to open a modal instead of a tooltip. I tried many different tooltip versions and didn't like any of them more than this for one reason or another. Notably, this allows you to copy text from the stat block without it adding any weird spaces.

## 🐢
