### PR TITLE
Misc Dragon Builder Fixes and Improvements

### DIFF
--- a/src/lib/dragon/dragon-config.ts
+++ b/src/lib/dragon/dragon-config.ts
@@ -6,7 +6,8 @@ import type {
 	PronounsConfig,
 	ProficiencyLevel,
 	SpellcastingConfig,
-	DisplaySpellStats
+	DisplaySpellStats,
+	Size
 } from '.';
 
 import {
@@ -32,6 +33,8 @@ export class DragonConfig {
 	name?: string;
 	disableNameCapitalization?: boolean;
 	statBlockTitle?: string;
+	size?: Size; // not a visible "Edit Dragon" option
+	type?: string; // not a visible "Edit Dragon" option
 	alignment?: string;
 	languages?: string;
 	pronouns?: Pronouns;
@@ -66,12 +69,19 @@ export class DragonConfig {
 	skillStealth?: ProficiencyLevel;
 	skillSurvival?: ProficiencyLevel;
 
+	vulnerabilities?: string; // not a visible "Edit Dragon" option
+	resistances?: string; // not a visible "Edit Dragon" option
+	immunities?: string; // not a visible "Edit Dragon" option
+
+	blindsight?: number | null; // not a visible "Edit Dragon" option
+	darkvision?: number | null; // not a visible "Edit Dragon" option
+
 	spellcasting?: SpellcastingConfig;
 	atWillSpells?: string;
 	dailySpells?: string;
 	displaySpellStats?: DisplaySpellStats;
 
-	shapechanged?: boolean;
+	shapechanged?: boolean; // not a visible "Edit Dragon" option
 
 	/**
 	 * Returns the title for this DragonConfig.

--- a/src/lib/dragon/dragon-config.ts
+++ b/src/lib/dragon/dragon-config.ts
@@ -13,6 +13,7 @@ import type {
 import {
 	stringToAge,
 	stringToColor,
+	stringToSize,
 	COLOR_TO_THEME,
 	DEFAULT_PRONOUNS,
 	ABILITIES,
@@ -136,6 +137,9 @@ export class DragonConfig {
 		if (this.statBlockTitle === '') {
 			delete this.statBlockTitle;
 		}
+		if (this.type === '') {
+			delete this.type;
+		}
 		if (this.alignment === '') {
 			delete this.alignment;
 		}
@@ -182,6 +186,13 @@ export class DragonConfig {
 			}
 		}
 
+		if (this.blindsight === null) {
+			delete this.blindsight;
+		}
+		if (this.darkvision === null) {
+			delete this.darkvision;
+		}
+
 		if (this.atWillSpells === '') {
 			delete this.atWillSpells;
 		}
@@ -212,6 +223,12 @@ export class DragonConfig {
 		}
 		if (this.statBlockTitle !== undefined) {
 			output.set('statBlockTitle', this.statBlockTitle);
+		}
+		if (this.size !== undefined) {
+			output.set('size', this.size);
+		}
+		if (this.type !== undefined) {
+			output.set('type', this.type);
 		}
 		if (this.alignment !== undefined) {
 			output.set('alignment', this.alignment);
@@ -268,6 +285,31 @@ export class DragonConfig {
 			if (thisSkillValue !== undefined) {
 				output.set(skill.key, thisSkillValue.toString());
 			}
+		}
+
+		if (this.vulnerabilities !== undefined) {
+			output.set('vulnerabilities', this.vulnerabilities);
+		}
+		if (this.resistances !== undefined) {
+			output.set('resistances', this.resistances);
+		}
+		if (this.immunities !== undefined) {
+			output.set('immunities', this.immunities);
+		}
+
+		if (
+			this.blindsight !== undefined &&
+			this.blindsight !== null &&
+			!Number.isNaN(this.blindsight)
+		) {
+			output.set('blindsight', Math.floor(this.blindsight).toString());
+		}
+		if (
+			this.darkvision !== undefined &&
+			this.darkvision !== null &&
+			!Number.isNaN(this.darkvision)
+		) {
+			output.set('darkvision', Math.floor(this.darkvision).toString());
 		}
 
 		if (this.spellcasting !== undefined) {
@@ -333,6 +375,19 @@ export class DragonConfig {
 
 		this.#setStatBlockTitleFromURLSearchParams(params);
 
+		const paramsSizeVal = params.get('size');
+		if (paramsSizeVal !== null) {
+			const paramsSize = stringToSize(paramsSizeVal);
+			if (paramsSize !== undefined) {
+				this.size = paramsSize;
+			}
+		}
+
+		const paramsTypeVal = params.get('type');
+		if (paramsTypeVal !== null) {
+			this.type = paramsTypeVal;
+		}
+
 		const paramsAlignmentVal = params.get('alignment');
 		if (paramsAlignmentVal !== null) {
 			this.alignment = paramsAlignmentVal;
@@ -352,6 +407,10 @@ export class DragonConfig {
 		this.#setAbilitiesFromURLSearchParams(params);
 
 		this.#setSkillsFromURLSearchParams(params);
+
+		this.#setDamageModifiersFromURLSearchParams(params);
+
+		this.#setSensesFromURLSearchParams(params);
 
 		this.#setSpellcastingFromURLSearchParams(params);
 		this.#setAtWillSpellsFromURLSearchParams(params);
@@ -517,6 +576,41 @@ export class DragonConfig {
 				) {
 					this[skill.key] = paramsSkillFloat;
 				}
+			}
+		}
+	}
+
+	#setDamageModifiersFromURLSearchParams(params: URLSearchParams) {
+		const paramsVulnerabilitiesVal = params.get('vulnerabilities');
+		if (paramsVulnerabilitiesVal !== null) {
+			this.vulnerabilities = paramsVulnerabilitiesVal;
+		}
+
+		const paramsResistancesVal = params.get('resistances');
+		if (paramsResistancesVal !== null) {
+			this.resistances = paramsResistancesVal;
+		}
+
+		const paramsImmunitiesVal = params.get('immunities');
+		if (paramsImmunitiesVal !== null) {
+			this.immunities = paramsImmunitiesVal;
+		}
+	}
+
+	#setSensesFromURLSearchParams(params: URLSearchParams) {
+		const paramsBlindsightVal = params.get('blindsight');
+		if (paramsBlindsightVal !== null) {
+			const paramsBlindsightInt = parseInt(paramsBlindsightVal);
+			if (!Number.isNaN(paramsBlindsightInt)) {
+				this.blindsight = paramsBlindsightInt;
+			}
+		}
+
+		const paramsDarkvisionVal = params.get('darkvision');
+		if (paramsDarkvisionVal !== null) {
+			const paramsDarkvisionInt = parseInt(paramsDarkvisionVal);
+			if (!Number.isNaN(paramsDarkvisionInt)) {
+				this.darkvision = paramsDarkvisionInt;
 			}
 		}
 	}

--- a/src/lib/dragon/dragon-config.ts
+++ b/src/lib/dragon/dragon-config.ts
@@ -71,6 +71,8 @@ export class DragonConfig {
 	dailySpells?: string;
 	displaySpellStats?: DisplaySpellStats;
 
+	shapechanged?: boolean;
+
 	/**
 	 * Returns the title for this DragonConfig.
 	 * @return {*}  {string}
@@ -176,6 +178,10 @@ export class DragonConfig {
 		if (this.dailySpells === '') {
 			delete this.dailySpells;
 		}
+
+		if (this.shapechanged === false) {
+			delete this.shapechanged;
+		}
 	}
 
 	/**
@@ -267,6 +273,10 @@ export class DragonConfig {
 			output.set('displaySpellStats', this.displaySpellStats);
 		}
 
+		if (this.shapechanged === true) {
+			output.set('shapechanged', '1');
+		}
+
 		return output;
 	}
 
@@ -337,6 +347,10 @@ export class DragonConfig {
 		this.#setAtWillSpellsFromURLSearchParams(params);
 		this.#setDailySpellsFromURLSearchParams(params);
 		this.#setDisplaySpellStatsFromURLSearchParams(params);
+
+		if (params.has('shapechanged')) {
+			this.shapechanged = true;
+		}
 
 		return true;
 	}

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -13,7 +13,9 @@ import {
 	abilityMin,
 	abilityMax,
 	scoreToMod,
-	expectedDiceResult
+	expectedDiceResult,
+	SHAPE_CHANGE_RETAINS_LEGENDARY_RESISTANCE,
+	SHAPE_CHANGE_RETAINS_INNATE_SPELLCASTING
 } from '.';
 import { capitalizeFirstLetter, numberWithSign } from '$lib/text-utils';
 import type { Age, Color, RGB, Size, Die, ProficiencyLevel, PronounsConfig } from '.';
@@ -414,10 +416,13 @@ export class DragonStats {
 
 	#getChangeShapeRetainedFeatures(): string[] {
 		const output: string[] = [];
-		if (this.legendaryResistances > 0) {
+		if (this.legendaryResistances > 0 && SHAPE_CHANGE_RETAINS_LEGENDARY_RESISTANCE) {
 			output.push('Legendary Resistance');
 		}
-		if (this.cantrips.length > 0 || this.spells.length > 0) {
+		if (
+			(this.cantrips.length > 0 || this.spells.length > 0) &&
+			SHAPE_CHANGE_RETAINS_INNATE_SPELLCASTING
+		) {
 			output.push('Innate Spellcasting');
 		}
 		return output;

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -208,6 +208,8 @@ export class DragonStats {
 		this.hasWallOfLight = this.age !== 'wyrmling' && this.age !== 'young';
 		this.wallLayers = this.#vals.wallLayers;
 
+		this.hasFrightfulFlare = this.age !== 'wyrmling' && this.age !== 'young';
+
 		this.prismaticRadianceRadius = this.#vals.prismaticRadianceRadius;
 
 		this.wingAttackRadius = this.#vals.wingAttackRadius;
@@ -565,6 +567,8 @@ export class DragonStats {
 
 	hasWallOfLight: boolean;
 	wallLayers: string;
+
+	hasFrightfulFlare: boolean;
 
 	prismaticRadianceRadius: number;
 

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -1,7 +1,7 @@
 import {
 	COLOR_TO_ALIGNMENT,
 	AGE_TO_SIZE,
-	AGE_TO_HIT_DIE,
+	ageToHitDie,
 	ABILITIES,
 	SKILLS,
 	DEFAULT_PRONOUNS,
@@ -66,7 +66,7 @@ export class DragonStats {
 		this.type = this.#getType();
 		this.ac = this.#vals.ac;
 		this.numberOfHitDice = this.#getNumberOfHitDice();
-		this.hitDie = AGE_TO_HIT_DIE[this.age];
+		this.hitDie = ageToHitDie(this.age);
 
 		this.speed = this.#vals.walkingSpeed;
 		this.burrowSpeed = this.#vals.burrowSpeed;

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -1,7 +1,7 @@
 import {
 	COLOR_TO_ALIGNMENT,
 	AGE_TO_SIZE,
-	SIZE_TO_HIT_DIE,
+	AGE_TO_HIT_DIE,
 	ABILITIES,
 	SKILLS,
 	DEFAULT_PRONOUNS,
@@ -65,7 +65,7 @@ export class DragonStats {
 		this.size = AGE_TO_SIZE[this.age];
 		this.ac = this.#vals.ac;
 		this.numberOfHitDice = this.#getNumberOfHitDice();
-		this.hitDie = SIZE_TO_HIT_DIE[this.size];
+		this.hitDie = AGE_TO_HIT_DIE[this.age];
 
 		this.speed = this.#vals.walkingSpeed;
 		this.burrowSpeed = this.#vals.burrowSpeed;

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -62,7 +62,8 @@ export class DragonStats {
 		this.pronounObjective = pronouns.objective;
 		this.pronounPossessiveAdjective = pronouns.possessiveAdjective;
 
-		this.size = AGE_TO_SIZE[this.age];
+		this.size = this.#getSize();
+		this.type = this.#getType();
 		this.ac = this.#vals.ac;
 		this.numberOfHitDice = this.#getNumberOfHitDice();
 		this.hitDie = AGE_TO_HIT_DIE[this.age];
@@ -91,15 +92,14 @@ export class DragonStats {
 		this.expectedHitPoints = this.#getExpectedHitPoints();
 
 		this.immunity = this.#vals.immunity;
-		this.additionalImmunities = this.#vals.additionalImmunities;
-		this.immunities = this.immunity + this.additionalImmunities;
-		this.resistances = this.#vals.resistances;
+		this.immunities = this.#getImmunities();
+		this.resistances = this.#getResistances();
 		this.vulnerability = this.#vals.vulnerability;
-		this.vulnerabilities = this.vulnerability;
+		this.vulnerabilities = this.#getVulnerabilities();
 		this.conditionImmunities = this.#vals.conditionImmunities;
 
-		this.blindsight = this.#vals.blindsight;
-		this.darkvision = this.#vals.darkvision;
+		this.blindsight = this.#getBlindsight();
+		this.darkvision = this.#getDarkvision();
 
 		this.languages = this.#config.languages ?? this.#vals.languages;
 
@@ -268,6 +268,22 @@ export class DragonStats {
 		}
 	}
 
+	#getSize(): Size {
+		if (this.#config.size !== undefined) {
+			return this.#config.size;
+		} else {
+			return AGE_TO_SIZE[this.age];
+		}
+	}
+
+	#getType(): string {
+		if (this.#config.type !== undefined) {
+			return this.#config.type;
+		} else {
+			return 'Dragon (Prismatic)';
+		}
+	}
+
 	#getNumberOfHitDice(): number {
 		if (
 			this.#config.numberOfHitDice !== undefined &&
@@ -352,6 +368,46 @@ export class DragonStats {
 			}
 		}
 		return skillsOutput;
+	}
+
+	#getImmunities(): string {
+		if (this.#config.immunities !== undefined) {
+			return this.#config.immunities;
+		} else {
+			return this.immunity + this.#vals.additionalImmunities;
+		}
+	}
+
+	#getResistances(): string {
+		return this.#config.resistances ?? this.#vals.resistances;
+	}
+
+	#getVulnerabilities(): string {
+		return this.#config.vulnerabilities ?? this.vulnerability;
+	}
+
+	#getBlindsight(): number {
+		if (
+			this.#config.blindsight !== undefined &&
+			this.#config.blindsight !== null &&
+			!Number.isNaN(this.#config.blindsight)
+		) {
+			return this.#config.blindsight;
+		} else {
+			return this.#vals.blindsight;
+		}
+	}
+
+	#getDarkvision(): number {
+		if (
+			this.#config.darkvision !== undefined &&
+			this.#config.darkvision !== null &&
+			!Number.isNaN(this.#config.darkvision)
+		) {
+			return this.#config.darkvision;
+		} else {
+			return this.#vals.darkvision;
+		}
 	}
 
 	#getCantrips(): string[] {
@@ -447,6 +503,7 @@ export class DragonStats {
 	pronounPossessiveAdjective: string;
 
 	size: Size;
+	type: string;
 	ac: number;
 	numberOfHitDice: number;
 	hitDie: Die;
@@ -475,7 +532,6 @@ export class DragonStats {
 	expectedHitPoints: number;
 
 	immunity: string;
-	additionalImmunities: string;
 	immunities: string;
 	resistances: string;
 	vulnerability: string;

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -204,8 +204,9 @@ export class DragonStats {
 		this.breath2DiceCount = this.#vals.breath2DiceCount;
 		this.breath2SpecialValue = this.#vals.breath2SpecialValue;
 
-		this.hasChangeShape = this.age !== 'wyrmling' && this.age !== 'young';
+		this.hasChangeShape = this.age === 'adult' || this.age === 'ancient';
 		this.changeShapeRetainedFeatures = this.#getChangeShapeRetainedFeatures();
+		this.isShapechanged = this.#config.shapechanged === true && this.hasChangeShape;
 
 		this.hasWallOfLight = this.age !== 'wyrmling' && this.age !== 'young';
 		this.wallLayers = this.#vals.wallLayers;
@@ -569,6 +570,7 @@ export class DragonStats {
 
 	hasChangeShape: boolean;
 	changeShapeRetainedFeatures: string[];
+	isShapechanged: boolean;
 
 	hasWallOfLight: boolean;
 	wallLayers: string;

--- a/src/lib/dragon/index.test.ts
+++ b/src/lib/dragon/index.test.ts
@@ -6,6 +6,9 @@ import {
 	COLORS,
 	COLORS_UPPER,
 	stringToColor,
+	AGE_TO_SIZE,
+	SIZE_TO_HIT_DIE,
+	AGE_TO_HIT_DIE,
 	scoreToMod,
 	expectedDiceResult,
 	type RGB,
@@ -34,6 +37,12 @@ test('COLORS_UPPER are Red, Orange, Yellow, Green, Blue, Indigo, and Violet', ()
 		'Indigo',
 		'Violet'
 	]);
+});
+
+test('AGE_TO_HIT_DIE[age] === SIZE_TO_HIT_DIE[AGE_TO_SIZE[age]] for all ages', () => {
+	for (const age of AGES) {
+		expect(AGE_TO_HIT_DIE[age]).toBe(SIZE_TO_HIT_DIE[AGE_TO_SIZE[age]]);
+	}
 });
 
 test('scoreToMod() behavior', () => {

--- a/src/lib/dragon/index.test.ts
+++ b/src/lib/dragon/index.test.ts
@@ -8,9 +8,6 @@ import {
 	stringToColor,
 	SIZES,
 	stringToSize,
-	AGE_TO_SIZE,
-	SIZE_TO_HIT_DIE,
-	AGE_TO_HIT_DIE,
 	scoreToMod,
 	expectedDiceResult,
 	type RGB,
@@ -46,12 +43,6 @@ test('stringToSize() behavior', () => {
 
 	for (const size of SIZES) {
 		expect(stringToSize(size)).toBe(size);
-	}
-});
-
-test('AGE_TO_HIT_DIE[age] === SIZE_TO_HIT_DIE[AGE_TO_SIZE[age]] for all ages', () => {
-	for (const age of AGES) {
-		expect(AGE_TO_HIT_DIE[age]).toBe(SIZE_TO_HIT_DIE[AGE_TO_SIZE[age]]);
 	}
 });
 

--- a/src/lib/dragon/index.test.ts
+++ b/src/lib/dragon/index.test.ts
@@ -6,6 +6,8 @@ import {
 	COLORS,
 	COLORS_UPPER,
 	stringToColor,
+	SIZES,
+	stringToSize,
 	AGE_TO_SIZE,
 	SIZE_TO_HIT_DIE,
 	AGE_TO_HIT_DIE,
@@ -37,6 +39,14 @@ test('COLORS_UPPER are Red, Orange, Yellow, Green, Blue, Indigo, and Violet', ()
 		'Indigo',
 		'Violet'
 	]);
+});
+
+test('stringToSize() behavior', () => {
+	expect(stringToSize('This is not a valid size.')).toBe(undefined);
+
+	for (const size of SIZES) {
+		expect(stringToSize(size)).toBe(size);
+	}
 });
 
 test('AGE_TO_HIT_DIE[age] === SIZE_TO_HIT_DIE[AGE_TO_SIZE[age]] for all ages', () => {

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -309,3 +309,6 @@ export type SpellcastingConfig = (typeof SPELLCASTING_CONFIG_OPTIONS)[number];
 
 export const DISPLAY_SPELL_STATS_OPTIONS = ['both', 'attack', 'saveDC', 'neither'] as const;
 export type DisplaySpellStats = (typeof DISPLAY_SPELL_STATS_OPTIONS)[number];
+
+export const SHAPE_CHANGE_RETAINS_LEGENDARY_RESISTANCE = true;
+export const SHAPE_CHANGE_RETAINS_INNATE_SPELLCASTING = true;

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -86,6 +86,16 @@ export const SIZE_TO_HIT_DIE: {
 	Gargantuan: 20
 } as const;
 
+export const AGE_TO_HIT_DIE: {
+	[key in Age]: Die;
+} = {
+	wyrmling: SIZE_TO_HIT_DIE[AGE_TO_SIZE['wyrmling']],
+	young: SIZE_TO_HIT_DIE[AGE_TO_SIZE['young']],
+	adult: SIZE_TO_HIT_DIE[AGE_TO_SIZE['adult']],
+	ancient: SIZE_TO_HIT_DIE[AGE_TO_SIZE['ancient']],
+	cosmic: SIZE_TO_HIT_DIE[AGE_TO_SIZE['cosmic']]
+} as const;
+
 export const ABILITIES = [
 	['strength', 'str'],
 	['dexterity', 'dex'],

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -62,6 +62,16 @@ export const COLOR_TO_THEME: {
 export const SIZES = ['Tiny', 'Small', 'Medium', 'Large', 'Huge', 'Gargantuan'] as const;
 export type Size = (typeof SIZES)[number];
 
+/**
+ * Converts input string to Size if possible, returning undefined if not.
+ * @export
+ * @param {string} sizeString
+ * @return {*}  {(Size | undefined)}
+ */
+export function stringToSize(sizeString: string): Size | undefined {
+	return SIZES.find((size) => size === sizeString);
+}
+
 export const AGE_TO_SIZE: {
 	[key in Age]: Size;
 } = {

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -96,15 +96,15 @@ export const SIZE_TO_HIT_DIE: {
 	Gargantuan: 20
 } as const;
 
-export const AGE_TO_HIT_DIE: {
-	[key in Age]: Die;
-} = {
-	wyrmling: SIZE_TO_HIT_DIE[AGE_TO_SIZE['wyrmling']],
-	young: SIZE_TO_HIT_DIE[AGE_TO_SIZE['young']],
-	adult: SIZE_TO_HIT_DIE[AGE_TO_SIZE['adult']],
-	ancient: SIZE_TO_HIT_DIE[AGE_TO_SIZE['ancient']],
-	cosmic: SIZE_TO_HIT_DIE[AGE_TO_SIZE['cosmic']]
-} as const;
+/**
+ * Returns the typical Hit Die for this age of dragon.
+ * @export
+ * @param {Age} age
+ * @return {*}  {Die}
+ */
+export function ageToHitDie(age: Age): Die {
+	return SIZE_TO_HIT_DIE[AGE_TO_SIZE[age]];
+}
 
 export const ABILITIES = [
 	['strength', 'str'],

--- a/src/lib/dragon/stat-block/AbbrButton.svelte
+++ b/src/lib/dragon/stat-block/AbbrButton.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
+	import { normalizeString } from '$lib/text-utils';
+
 	export let title: string;
+
+	let abbrID = `abbrevationDropdown__${normalizeString(title)}`;
 </script>
 
 <div class="daisy-dropdown daisy-dropdown-hover">
-	<label for="testfsdf">
+	<label for={abbrID}>
 		<button class="underline decoration-dotted"><slot /></button>
 	</label>
 	<div
+		id={abbrID}
 		class="daisy-card daisy-compact daisy-dropdown-content z-[1] shadow bg-base-100 rounded-box border border-black min-w-[8rem]"
 	>
 		<div class="daisy-card-body">

--- a/src/lib/dragon/stat-block/AbbrButton.svelte
+++ b/src/lib/dragon/stat-block/AbbrButton.svelte
@@ -1,12 +1,18 @@
 <script lang="ts">
-	import { normalizeString } from '$lib/text-utils';
+	import { getModalStore, type ModalSettings } from '@skeletonlabs/skeleton';
 
-	export let title: string;
+	const modalStore = getModalStore();
+	const modalConfig: ModalSettings = {
+		type: 'component',
+		component: 'abbrModal'
+	};
 
-	let abbrID = `abbrevationDropdown__${normalizeString(title)}`;
+	export let abbreviation: string;
+	export let definition: string;
 
 	function handleClick() {
-		// no action required
+		modalConfig.value = { abbreviation, definition };
+		modalStore.trigger(modalConfig);
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
@@ -22,23 +28,11 @@
 	}
 </script>
 
-<div class="daisy-dropdown daisy-dropdown-hover">
-	<label for={abbrID}>
-		<span
-			role="button"
-			tabindex="0"
-			on:keydown={handleKeydown}
-			on:keyup={handleKeyup}
-			on:click={handleClick}
-			class="underline decoration-dotted"><slot /></span
-		>
-	</label>
-	<div
-		id={abbrID}
-		class="daisy-card daisy-compact daisy-dropdown-content z-[1] shadow bg-base-100 rounded-box border border-black min-w-[8rem]"
-	>
-		<div class="daisy-card-body">
-			<p class="font-normal not-italic">{title}</p>
-		</div>
-	</div>
-</div>
+<span
+	role="button"
+	tabindex="0"
+	on:keydown={handleKeydown}
+	on:keyup={handleKeyup}
+	on:click={handleClick}
+	class="underline print:no-underline">{abbreviation}</span
+>

--- a/src/lib/dragon/stat-block/AbbrButton.svelte
+++ b/src/lib/dragon/stat-block/AbbrButton.svelte
@@ -4,11 +4,34 @@
 	export let title: string;
 
 	let abbrID = `abbrevationDropdown__${normalizeString(title)}`;
+
+	function handleClick() {
+		// no action required
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === ' ') {
+			handleClick();
+		}
+	}
+
+	function handleKeyup(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			handleClick();
+		}
+	}
 </script>
 
 <div class="daisy-dropdown daisy-dropdown-hover">
 	<label for={abbrID}>
-		<button class="underline decoration-dotted"><slot /></button>
+		<span
+			role="button"
+			tabindex="0"
+			on:keydown={handleKeydown}
+			on:keyup={handleKeyup}
+			on:click={handleClick}
+			class="underline decoration-dotted"><slot /></span
+		>
 	</label>
 	<div
 		id={abbrID}

--- a/src/lib/dragon/stat-block/UpcastAbbr.svelte
+++ b/src/lib/dragon/stat-block/UpcastAbbr.svelte
@@ -6,13 +6,12 @@
 	export let level: SpellLevel;
 
 	let maxLevelWithOrdinal = numberWithOrdinalSuffix(level);
+	let abbreviation = `Upcast to ${maxLevelWithOrdinal} Level`;
 	let affectedLevels =
 		level > 2 ? `1st through ${numberWithOrdinalSuffix(level - 1)} level` : '1st level';
-	let abbrTitle = `Spells of ${affectedLevels} are cast at ${maxLevelWithOrdinal} level.`;
+	let definition = `Spells of ${affectedLevels} are cast at ${maxLevelWithOrdinal} level.`;
 </script>
 
 {#if level > 1}
-	{' ('}<AbbrButton title={abbrTitle}>
-		<span class="italic">Upcast to {maxLevelWithOrdinal} Level</span>
-	</AbbrButton>{')'}
+	{' ('}<AbbrButton {abbreviation} {definition} />{')'}
 {/if}

--- a/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
+++ b/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
@@ -32,8 +32,7 @@
 		</p>
 		<p>
 			In the new form, {dragon.name} retains {dragon.pronounPossessiveAdjective}
-			<AbbrButton title="personality, alignment, and known languages">personality</AbbrButton>, hit
-			points, mental ability scores,
+			personality, known languages, hit points, mental ability scores,
 			{#if dragon.changeShapeRetainedFeatures.length < 1}
 				and proficiencies,
 			{:else}

--- a/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
+++ b/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
@@ -8,6 +8,8 @@
 	let retainedFeatures: string;
 	$: if (dragon.changeShapeRetainedFeatures.length < 1) {
 		retainedFeatures = '';
+	} else if (dragon.changeShapeRetainedFeatures.length === 1) {
+		retainedFeatures = `and ${dragon.changeShapeRetainedFeatures[0]}`;
 	} else {
 		retainedFeatures = '';
 		const retainedFeaturesArray: string[] = JSON.parse(

--- a/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
+++ b/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { capitalizeFirstLetter } from '$lib/text-utils';
 	import type { DragonStats } from '$lib/dragon/dragon-stats';
-	import AbbrButton from '../AbbrButton.svelte';
 
 	export let dragon: DragonStats;
 

--- a/src/lib/dragon/stat-block/actions/StatBlockActions.svelte
+++ b/src/lib/dragon/stat-block/actions/StatBlockActions.svelte
@@ -15,10 +15,14 @@
 	<StatBlockDivider color={dragon.theme} height={dividerHeightThin} classes={'mt-0'} />
 </div>
 
-<ActionAttacks {dragon} />
+{#if dragon.isShapechanged}
+	<ActionChangeShape {dragon} />
+{:else}
+	<ActionAttacks {dragon} />
 
-<ActionBreathWeapons {dragon} />
+	<ActionBreathWeapons {dragon} />
 
-<ActionChangeShape {dragon} />
+	<ActionChangeShape {dragon} />
 
-<ActionWallOfLight {dragon} />
+	<ActionWallOfLight {dragon} />
+{/if}

--- a/src/lib/dragon/stat-block/bonus-actions/BActionFrightfulFlare.svelte
+++ b/src/lib/dragon/stat-block/bonus-actions/BActionFrightfulFlare.svelte
@@ -6,7 +6,7 @@
 	export let dragon: DragonStats;
 </script>
 
-{#if dragon.age !== 'wyrmling' && dragon.age !== 'young'}
+{#if dragon.hasFrightfulFlare}
 	<div class="dragon-action">
 		<p>
 			<i>

--- a/src/lib/dragon/stat-block/bonus-actions/BActionFrightfulFlare.svelte
+++ b/src/lib/dragon/stat-block/bonus-actions/BActionFrightfulFlare.svelte
@@ -4,17 +4,16 @@
 	import AbbrButton from '../AbbrButton.svelte';
 
 	export let dragon: DragonStats;
+
+	let abbreviation = '1/SR';
+	let definition = 'Recharges after a Short or Long Rest';
 </script>
 
 {#if dragon.hasFrightfulFlare}
 	<div class="dragon-action">
 		<p>
 			<i>
-				<b
-					>Frightful Flare (<AbbrButton title="Recharges after a Short or Long Rest"
-						><span class="italic">1/SR</span></AbbrButton
-					>).
-				</b>
+				<b>Frightful Flare (<AbbrButton {abbreviation} {definition} />). </b>
 			</i>
 			{dragon.nameUpper} unleashes {dragon.pronounPossessiveAdjective} inner light, maxing out {dragon.pronounPossessiveAdjective}
 			Variable Radiance to a radius of {dragon.prismaticRadianceRadius} feet. Each creature of {dragon.name}'s

--- a/src/lib/dragon/stat-block/bonus-actions/BActionVariableRadiance.svelte
+++ b/src/lib/dragon/stat-block/bonus-actions/BActionVariableRadiance.svelte
@@ -9,15 +9,17 @@
 	export let dragon: DragonStats;
 
 	let penalties: string;
+	let penalize_secondary_breath_saves = RADIANCE_PENALIZES_SECONDARY_BREATH_SAVES;
+	let penalize_flare_saves = RADIANCE_PENALIZES_FRIGHTFUL_FLARE_SAVES && dragon.hasFrightfulFlare;
 	$: {
 		penalties = '';
-		if (RADIANCE_PENALIZES_SECONDARY_BREATH_SAVES) {
+		if (penalize_secondary_breath_saves) {
 			penalties += `${dragon.breath2Name} Breath`;
 		}
-		if (RADIANCE_PENALIZES_SECONDARY_BREATH_SAVES && RADIANCE_PENALIZES_FRIGHTFUL_FLARE_SAVES) {
+		if (penalize_secondary_breath_saves && penalize_flare_saves) {
 			penalties += ' and ';
 		}
-		if (RADIANCE_PENALIZES_FRIGHTFUL_FLARE_SAVES) {
+		if (penalize_flare_saves) {
 			penalties += 'Frightful Flare';
 		}
 	}
@@ -29,7 +31,7 @@
 		{dragon.nameUpper} chooses a radius up to {dragon.prismaticRadianceRadius}
 		feet and glows {dragon.color}, shedding bright light in the chosen radius and dim light for an
 		additional distance equal to the chosen radius.
-		{#if RADIANCE_PENALIZES_SECONDARY_BREATH_SAVES || RADIANCE_PENALIZES_FRIGHTFUL_FLARE_SAVES}
+		{#if penalties}
 			Creatures within this bright light have a −{RADIANCE_PENALTY} penalty to their saving throws against
 			{dragon.name}'s
 			{penalties}.

--- a/src/lib/dragon/stat-block/bonus-actions/StatBlockBonusActions.svelte
+++ b/src/lib/dragon/stat-block/bonus-actions/StatBlockBonusActions.svelte
@@ -9,13 +9,15 @@
 	export let dragon: DragonStats;
 </script>
 
-<div class="break-inside-avoid break-after-avoid">
-	<h5 class="dragon-heading-font text-xl">Bonus Actions</h5>
-	<StatBlockDivider color={dragon.theme} height={dividerHeightThin} classes={'mt-0'} />
-</div>
+{#if !dragon.isShapechanged}
+	<div class="break-inside-avoid break-after-avoid">
+		<h5 class="dragon-heading-font text-xl">Bonus Actions</h5>
+		<StatBlockDivider color={dragon.theme} height={dividerHeightThin} classes={'mt-0'} />
+	</div>
 
-<BActionFrightfulFlare {dragon} />
+	<BActionFrightfulFlare {dragon} />
 
-<BActionSupernova {dragon} />
+	<BActionSupernova {dragon} />
 
-<BActionVariableRadiance {dragon} />
+	<BActionVariableRadiance {dragon} />
+{/if}

--- a/src/lib/dragon/stat-block/features/StatBlockFeatures.svelte
+++ b/src/lib/dragon/stat-block/features/StatBlockFeatures.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+	import {
+		SHAPE_CHANGE_RETAINS_LEGENDARY_RESISTANCE,
+		SHAPE_CHANGE_RETAINS_INNATE_SPELLCASTING
+	} from '$lib/dragon';
 	import type { DragonStats } from '$lib/dragon/dragon-stats';
 	import FeatureAmphibious from './FeatureAmphibious.svelte';
 	import FeatureInnateSpellcasting from './FeatureInnateSpellcasting.svelte';
@@ -8,10 +12,20 @@
 	export let dragon: DragonStats;
 </script>
 
-<FeatureAmphibious {dragon} />
+{#if dragon.isShapechanged}
+	{#if SHAPE_CHANGE_RETAINS_INNATE_SPELLCASTING}
+		<FeatureInnateSpellcasting {dragon} />
+	{/if}
 
-<FeatureInnateSpellcasting {dragon} />
+	{#if SHAPE_CHANGE_RETAINS_LEGENDARY_RESISTANCE}
+		<FeatureLegendaryResistance {dragon} />
+	{/if}
+{:else}
+	<FeatureAmphibious {dragon} />
 
-<FeatureLegendaryResistance {dragon} />
+	<FeatureInnateSpellcasting {dragon} />
 
-<FeatureMagicWeapons {dragon} />
+	<FeatureLegendaryResistance {dragon} />
+
+	<FeatureMagicWeapons {dragon} />
+{/if}

--- a/src/lib/dragon/stat-block/legendary-actions/StatBlockLegendaryActions.svelte
+++ b/src/lib/dragon/stat-block/legendary-actions/StatBlockLegendaryActions.svelte
@@ -9,7 +9,7 @@
 	export let dragon: DragonStats;
 </script>
 
-{#if dragon.age !== 'wyrmling' && dragon.age !== 'young'}
+{#if dragon.age !== 'wyrmling' && dragon.age !== 'young' && !dragon.isShapechanged}
 	<div class="break-inside-avoid break-after-avoid">
 		<h5 class="dragon-heading-font text-xl">Legendary Actions</h5>
 		<StatBlockDivider color={dragon.theme} height={dividerHeightThin} classes={'mt-0'} />

--- a/src/lib/dragon/stat-block/preamble/PreambleHeader.svelte
+++ b/src/lib/dragon/stat-block/preamble/PreambleHeader.svelte
@@ -7,6 +7,6 @@
 <div class="dragon-header">
 	<div>
 		<h4 class="dragon-title">{dragon.title}</h4>
-		<p class="dragon-subheading">{dragon.size} Dragon (Prismatic), {dragon.alignment}</p>
+		<p class="dragon-subheading">{dragon.size} {dragon.type}, {dragon.alignment}</p>
 	</div>
 </div>

--- a/src/lib/dragon/stat-block/preamble/PreambleStatsList.svelte
+++ b/src/lib/dragon/stat-block/preamble/PreambleStatsList.svelte
@@ -49,12 +49,14 @@
 		</li>
 	{/if}
 
-	<li class="dragon-immunities my-1">
-		<p class="-indent-4 pl-4">
-			<span class="dragon-label">Damage Immunities</span>
-			<span class="lowercase">{dragon.immunities}</span>
-		</p>
-	</li>
+	{#if dragon.immunities.length > 0}
+		<li class="dragon-immunities my-1">
+			<p class="-indent-4 pl-4">
+				<span class="dragon-label">Damage Immunities</span>
+				<span class="lowercase">{dragon.immunities}</span>
+			</p>
+		</li>
+	{/if}
 
 	{#if dragon.conditionImmunities.length > 0}
 		<li class="dragon-conditions my-1">
@@ -70,19 +72,25 @@
 			<span class="dragon-label">Senses</span>
 			<span>
 				{#if dragon.age === 'cosmic'}
-					<span class="whitespace-nowrap">
-						truesight
-						{dragon.blindsight} ft.,
-					</span>
+					{#if dragon.blindsight > 0}
+						<span class="whitespace-nowrap">
+							truesight
+							{dragon.blindsight} ft.,
+						</span>
+					{/if}
 				{:else}
-					<span class="whitespace-nowrap">
-						blindsight
-						{dragon.blindsight} ft.,
-					</span>
-					<span class="whitespace-nowrap">
-						darkvision
-						{dragon.darkvision} ft.,
-					</span>
+					{#if dragon.blindsight > 0}
+						<span class="whitespace-nowrap">
+							blindsight
+							{dragon.blindsight} ft.,
+						</span>
+					{/if}
+					{#if dragon.darkvision > 0}
+						<span class="whitespace-nowrap">
+							darkvision
+							{dragon.darkvision} ft.,
+						</span>
+					{/if}
 				{/if}
 				<span class="whitespace-nowrap">passive Perception {dragon.passivePerception}</span>
 			</span>

--- a/src/lib/modals/AbbrModal.svelte
+++ b/src/lib/modals/AbbrModal.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	// Props
+	/** Exposes parent props to this component. */
+	export let parent: {
+		position: string;
+		// ---
+		background: string;
+		width: string;
+		height: string;
+		padding: string;
+		spacing: string;
+		rounded: string;
+		shadow: string;
+		// ---
+		buttonNeutral: string;
+		buttonPositive: string;
+		buttonTextCancel: string;
+		buttonTextConfirm: string;
+		buttonTextSubmit: string;
+		// ---
+		regionBackdrop: string;
+		regionHeader: string;
+		regionBody: string;
+		regionFooter: string;
+		// ---
+		onClose: () => void;
+	};
+
+	// Stores
+	import { getModalStore } from '@skeletonlabs/skeleton';
+	const modalStore = getModalStore();
+
+	let abbrInfo: { abbreviation: string; definition: string } = $modalStore[0].value;
+</script>
+
+{#if $modalStore[0]}
+	<div class="card p-4 w-modal shadow-xl space-y-4 overflow-x-clip">
+		<header class="text-2xl font-bold">Abbreviation: {abbrInfo.abbreviation}</header>
+		<div>Definition: {abbrInfo.definition}</div>
+		<footer class="modal-footer {parent.regionFooter}">
+			<button class="btn {parent.buttonNeutral}" on:click={parent.onClose}> Close </button>
+		</footer>
+	</div>
+{/if}

--- a/src/lib/spells/SpellLink.svelte
+++ b/src/lib/spells/SpellLink.svelte
@@ -17,6 +17,25 @@
 		spellModal.value = { name: spellName, id: spellID };
 		modalStore.trigger(spellModal);
 	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === ' ') {
+			handleClick();
+		}
+	}
+
+	function handleKeyup(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			handleClick();
+		}
+	}
 </script>
 
-<button on:click={handleClick} class="italic underline">{spellName}</button>
+<span
+	role="button"
+	tabindex="0"
+	on:click={handleClick}
+	on:keydown={handleKeydown}
+	on:keyup={handleKeyup}
+	class="italic underline">{spellName}</span
+>

--- a/src/lib/spells/SpellLink.svelte
+++ b/src/lib/spells/SpellLink.svelte
@@ -37,5 +37,5 @@
 	on:click={handleClick}
 	on:keydown={handleKeydown}
 	on:keyup={handleKeyup}
-	class="italic underline">{spellName}</span
+	class="italic underline print:no-underline">{spellName}</span
 >

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 
 	import { initializeStores, type ModalComponent } from '@skeletonlabs/skeleton';
 	import { AppShell, Modal, Toast } from '@skeletonlabs/skeleton';
+	import AbbrModal from '$lib/modals/AbbrModal.svelte';
 	import AddLocalSpell from '$lib/modals/AddLocalSpell.svelte';
 	import ManageLocalSpells from '$lib/modals/ManageLocalSpells.svelte';
 	import DragonShare from '$lib/modals/DragonShare.svelte';
@@ -17,6 +18,9 @@
 	initializeStores();
 
 	const modalComponentRegistry: Record<string, ModalComponent> = {
+		abbrModal: {
+			ref: AbbrModal
+		},
 		addLocalSpell: {
 			ref: AddLocalSpell
 		},


### PR DESCRIPTION
## What's in this PR?
This PR makes multiple fixes and improvements to the Dragon Builder:
1. The buttons for abbreviations/spells are now `span` elements, allowing you to highlight/copy the text without issues.
2. Frightful Flare was mentioned in Variable Radiance for dragons without it. It no longer does that.
3. Updated Change Shape to no longer need an abbreviation element.
4. Added some new URL params for Shape Change stat blocks, but it ended up being more work than I want to do right now, so the params only do part of the work to edit a stat block enough. These params aren't in the edit form since I don't plan on suggesting them to users.
5. The AbbrButton components now open a modal instead of having a tooltip.

## 🐢
