### PR TITLE
Added static monster pages for dragons + descriptions

### DIFF
--- a/src/lib/StandardCard.svelte
+++ b/src/lib/StandardCard.svelte
@@ -1,3 +1,7 @@
-<div class="card text-token text-left relative">
+<script lang="ts">
+	export let additionalClasses = '';
+</script>
+
+<div class="card text-token text-left relative {additionalClasses}">
 	<slot />
 </div>

--- a/src/lib/dragon/DragonBuilder.svelte
+++ b/src/lib/dragon/DragonBuilder.svelte
@@ -26,6 +26,8 @@
 	import BuilderDebug from './builder-states/BuilderDebug.svelte';
 	import DragonControlButtons from './DragonControlButtons.svelte';
 	import DragonDebugButtons from './DragonDebugButtons.svelte';
+	import StandardCard from '$lib/StandardCard.svelte';
+	import DragonDescription from './descriptions/DragonDescription.svelte';
 
 	const modalStore = getModalStore();
 	const shareModal: ModalSettings = {
@@ -145,8 +147,14 @@
 	</DragonContainer>
 
 	{#if $currentBuilderState === 'DISPLAY' && $nextBuilderState === undefined}
-		<div transition:fade={builderFadeParams} class="w-fit">
-			<DragonControlButtons on:click={handleControlClick} />
+		<div transition:fade={builderFadeParams} class="w-full">
+			<div class="w-fit mx-auto">
+				<DragonControlButtons on:click={handleControlClick} />
+			</div>
+
+			<StandardCard additionalClasses="p-4 mt-2">
+				<DragonDescription config={$currentDragonConfig} />
+			</StandardCard>
 		</div>
 	{/if}
 

--- a/src/lib/dragon/descriptions/AgeDescriptionAdult.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionAdult.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Adult Dragons</h3>
+<p>Adult dragons. Yep.</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionAdult.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionAdult.svelte
@@ -1,2 +1,5 @@
 <h3 class="text-lg font-bold">Adult Dragons</h3>
-<p>Adult dragons. Yep.</p>
+<p>
+	Adult dragons have unlocked the full power of their kind. Generally between 100 and 800 years old,
+	adult dragons are able to use legendary abilities.
+</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionAncient.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionAncient.svelte
@@ -1,2 +1,5 @@
 <h3 class="text-lg font-bold">Ancient Dragons</h3>
-<p>Ancient dragons. Yep.</p>
+<p>
+	Prismatic dragons become ancient around the age of 1000 years old. Their scales are so strong now
+	that nonmagical weapons aren't as effective against them.
+</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionAncient.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionAncient.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Ancient Dragons</h3>
+<p>Ancient dragons. Yep.</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionCosmic.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionCosmic.svelte
@@ -1,2 +1,7 @@
 <h3 class="text-lg font-bold">Cosmic Dragons</h3>
-<p>Cosmic dragons. Yep.</p>
+<p>
+	Cosmic dragons are generally in the last decade of their life. Their power has begun to exceed the
+	limits of their mortal form. They can no longer safely change their shape into beast or humanoid
+	forms; attempting to do so causes a series of explosions that ultimately ends with their
+	destruction.
+</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionCosmic.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionCosmic.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Cosmic Dragons</h3>
+<p>Cosmic dragons. Yep.</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionWyrmling.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionWyrmling.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold mt-2">Wyrmlings</h3>
+<p>Wyrmlings are the youngest age category of dragon.</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionWyrmling.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionWyrmling.svelte
@@ -1,2 +1,2 @@
-<h3 class="text-lg font-bold mt-2">Wyrmlings</h3>
+<h3 class="text-lg font-bold">Wyrmlings</h3>
 <p>Wyrmlings are the youngest age category of dragon.</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionWyrmling.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionWyrmling.svelte
@@ -1,2 +1,2 @@
 <h3 class="text-lg font-bold">Wyrmlings</h3>
-<p>Wyrmlings are the youngest age category of dragon.</p>
+<p>Wyrmlings are the youngest of dragons, less than a decade old.</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionYoung.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionYoung.svelte
@@ -1,2 +1,2 @@
 <h3 class="text-lg font-bold">Young Dragons</h3>
-<p>Young dragons are the second-youngest age category.</p>
+<p>Young dragons are generally between 10 and 100 years old.</p>

--- a/src/lib/dragon/descriptions/AgeDescriptionYoung.svelte
+++ b/src/lib/dragon/descriptions/AgeDescriptionYoung.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Young Dragons</h3>
+<p>Young dragons are the second-youngest age category.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionBlack.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionBlack.svelte
@@ -1,2 +1,9 @@
 <h3 class="text-lg font-bold">Prismatic Black Dragons</h3>
-<p>This is the description for black dragons.</p>
+<p>
+	Black dragons are born when any dragon egg hatches during a total solar eclipse. As such they are
+	the rarest of the prismatic dragons, but their lifespan is seemingly indefinite, with the oldest
+	known black dragon nearing 3000 years old. A black dragon might be found trying to escape the cult
+	that forced their birth, running a hospital which develops quality-of-life-focused medical
+	approaches, or living on a secluded mountain to avoid the throngs of people seeking lifespan
+	extension.
+</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionBlack.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionBlack.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Prismatic Black Dragons</h3>
+<p>This is the description for black dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionBlue.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionBlue.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Prismatic Blue Dragons</h3>
+<p>This is the description for blue dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionBlue.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionBlue.svelte
@@ -1,2 +1,7 @@
 <h3 class="text-lg font-bold">Prismatic Blue Dragons</h3>
-<p>This is the description for blue dragons.</p>
+<p>
+	Blue dragons are often fascinated by the thrill of new discovery, especially in the realm of
+	science and magic. A blue dragon might be found running a magical university, performing social
+	experiments on unsuspecting humans, or methodically testing whether teleportation into the sun is
+	possible.
+</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionGreen.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionGreen.svelte
@@ -1,2 +1,7 @@
 <h3 class="text-lg font-bold">Prismatic Green Dragons</h3>
-<p>This is the description for green dragons.</p>
+<p>
+	Green dragons, the protectors of nature, are the most in touch with the land. The indefinite sleep
+	breath of adult and ancient green dragons has also fueled countless legends about them. They might
+	be found tending an herb garden in a treacherous mountain pass, negotiating for the establishment
+	of a nature preserve, or building an army of sleeping adventurers to get revenge on a nearby city.
+</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionGreen.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionGreen.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Prismatic Green Dragons</h3>
+<p>This is the description for green dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionIndigo.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionIndigo.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Prismatic Indigo Dragons</h3>
+<p>This is the description for indigo dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionIndigo.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionIndigo.svelte
@@ -1,2 +1,8 @@
 <h3 class="text-lg font-bold">Prismatic Indigo Dragons</h3>
-<p>This is the description for indigo dragons.</p>
+<p>
+	Indigo dragons are described in tales as terrifying sea serpents, emerging from the ocean depths
+	to petrify and sink unsuspecting sailors. Whatever humanoids say about them, these often
+	hard-to-read dragons can have varied motivations and goals. An indigo dragon might be the captain
+	of a notorious band of pirates, the curator of a suspicious statue museum, or the guardian of a
+	tropical island and its surrounding coral reef.
+</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionMagenta.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionMagenta.svelte
@@ -1,2 +1,8 @@
 <h3 class="text-lg font-bold">Prismatic Magenta Dragons</h3>
-<p>This is the description for magenta dragons.</p>
+<p>
+	There are rumors of magenta dragons living among us in secret, kept safe by their memory-modifying
+	magical powers. Whether or not they truly exist in your setting, conspiracy theories about their
+	existence almost certainly do. A magenta dragon (real or theoretical) might infiltrate an enemy
+	government from the inside, maintain a sanctuary for those with powerful enemies, or work as an
+	enigmatic assassin whose murders never seem to have any witnesses.
+</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionMagenta.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionMagenta.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Prismatic Magenta Dragons</h3>
+<p>This is the description for magenta dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionOrange.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionOrange.svelte
@@ -1,2 +1,6 @@
 <h3 class="text-lg font-bold">Prismatic Orange Dragons</h3>
-<p>This is the description for orange dragons.</p>
+<p>
+	Orange dragons are taught from a young age to think militarily, assessing anything as a potential
+	threat. They also place a high value on the discipline of mastering a craft. An orange dragon
+	might be a general on the battlefield, a world-renowned chef, or a beloved blacksmithing teacher.
+</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionOrange.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionOrange.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Prismatic Orange Dragons</h3>
+<p>This is the description for orange dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionRed.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionRed.svelte
@@ -1,2 +1,6 @@
 <h3 class="text-lg font-bold">Prismatic Red Dragons</h3>
-<p>This is the description for red dragons.</p>
+<p>
+	Red dragons are the most emotionally in-touch and human-like of the prismatic dragons. They can be
+	found anywhere from jealously guarding their hoard of gold to pursuing an acting career with the
+	local theater guild.
+</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionRed.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionRed.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold mt-2">Prismatic Red Dragons</h3>
+<p>This is the description for red dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionRed.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionRed.svelte
@@ -1,2 +1,2 @@
-<h3 class="text-lg font-bold mt-2">Prismatic Red Dragons</h3>
+<h3 class="text-lg font-bold">Prismatic Red Dragons</h3>
 <p>This is the description for red dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionViolet.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionViolet.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Prismatic Violet Dragons</h3>
+<p>This is the description for violet dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionViolet.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionViolet.svelte
@@ -1,2 +1,7 @@
 <h3 class="text-lg font-bold">Prismatic Violet Dragons</h3>
-<p>This is the description for violet dragons.</p>
+<p>
+	Orderly to a fault, many violet dragons would rule the world with an iron fist and a stack of
+	paperwork if they could. A violet dragon might be found working as a pro-bono lawyer, defending a
+	major city under siege, or plotting the demise of their sister who is first in line for the
+	throne.
+</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionWhite.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionWhite.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Prismatic White Dragons</h3>
+<p>This is the description for white dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionWhite.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionWhite.svelte
@@ -1,2 +1,8 @@
 <h3 class="text-lg font-bold">Prismatic White Dragons</h3>
-<p>This is the description for white dragons.</p>
+<p>
+	White dragons live short, explosively powerful lives. They are extremely rare and die before
+	reaching 200 years of age, but they almost always leave a significant mark on the world, for
+	better or for worse. A white dragon might be the champion defender of an empire during a great
+	war, the terrible tyrant that burns a civilization to the ground, or the prophet of a new and
+	fast-spreading religion.
+</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionYellow.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionYellow.svelte
@@ -1,0 +1,2 @@
+<h3 class="text-lg font-bold">Prismatic Yellow Dragons</h3>
+<p>This is the description for yellow dragons.</p>

--- a/src/lib/dragon/descriptions/ColorDescriptionYellow.svelte
+++ b/src/lib/dragon/descriptions/ColorDescriptionYellow.svelte
@@ -1,2 +1,7 @@
 <h3 class="text-lg font-bold">Prismatic Yellow Dragons</h3>
-<p>This is the description for yellow dragons.</p>
+<p>
+	Yellow dragons value knowledge and wit above all else, and are especially concerned with creating
+	and preserving records. A yellow dragon might be found teaching at the local public school,
+	stealing archeological wonders for their private hoard, or maintaining an ancient hidden library
+	in the Border Ethereal.
+</p>

--- a/src/lib/dragon/descriptions/DragonDescription.svelte
+++ b/src/lib/dragon/descriptions/DragonDescription.svelte
@@ -1,18 +1,23 @@
 <script lang="ts">
-	import type { Age, Color } from '..';
+	import type { DragonConfig } from '../dragon-config';
 
 	import ColorDescriptionRed from './ColorDescriptionRed.svelte';
 
 	import AgeDescriptionWyrmling from './AgeDescriptionWyrmling.svelte';
 
-	export let age: Age;
-	export let color: Color;
+	export let config: DragonConfig | undefined;
 </script>
 
-{#if color === 'red'}
-	<ColorDescriptionRed />
-{/if}
+{#if config !== undefined}
+	<div>
+		{#if config?.color === 'red'}
+			<ColorDescriptionRed />
+		{/if}
+	</div>
 
-{#if age === 'wyrmling'}
-	<AgeDescriptionWyrmling />
+	<div class="mt-2">
+		{#if config?.age === 'wyrmling'}
+			<AgeDescriptionWyrmling />
+		{/if}
+	</div>
 {/if}

--- a/src/lib/dragon/descriptions/DragonDescription.svelte
+++ b/src/lib/dragon/descriptions/DragonDescription.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 	import type { DragonConfig } from '../dragon-config';
+	import { DragonStats } from '../dragon-stats';
+
+	import DragonLairActions from '../stat-block/lair-actions/DragonLairActions.svelte';
 
 	import ColorDescriptionRed from './ColorDescriptionRed.svelte';
 	import ColorDescriptionOrange from './ColorDescriptionOrange.svelte';
@@ -19,10 +22,18 @@
 	import AgeDescriptionCosmic from './AgeDescriptionCosmic.svelte';
 
 	export let config: DragonConfig | undefined;
+
+	let dragon: DragonStats | undefined;
+
+	$: dragon = config !== undefined ? new DragonStats(config) : undefined;
 </script>
 
 {#if config !== undefined}
-	<div>
+	{#if dragon !== undefined}
+		<DragonLairActions {dragon} />
+	{/if}
+
+	<div class="mb-2">
 		{#if config.color === 'red'}
 			<ColorDescriptionRed />
 		{:else if config.color === 'orange'}
@@ -46,7 +57,7 @@
 		{/if}
 	</div>
 
-	<div class="mt-2">
+	<div>
 		{#if config.age === 'wyrmling'}
 			<AgeDescriptionWyrmling />
 		{:else if config.age === 'young'}

--- a/src/lib/dragon/descriptions/DragonDescription.svelte
+++ b/src/lib/dragon/descriptions/DragonDescription.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { Age, Color } from '..';
+
+	import ColorDescriptionRed from './ColorDescriptionRed.svelte';
+
+	import AgeDescriptionWyrmling from './AgeDescriptionWyrmling.svelte';
+
+	export let age: Age;
+	export let color: Color;
+</script>
+
+{#if color === 'red'}
+	<ColorDescriptionRed />
+{/if}
+
+{#if age === 'wyrmling'}
+	<AgeDescriptionWyrmling />
+{/if}

--- a/src/lib/dragon/descriptions/DragonDescription.svelte
+++ b/src/lib/dragon/descriptions/DragonDescription.svelte
@@ -2,22 +2,61 @@
 	import type { DragonConfig } from '../dragon-config';
 
 	import ColorDescriptionRed from './ColorDescriptionRed.svelte';
+	import ColorDescriptionOrange from './ColorDescriptionOrange.svelte';
+	import ColorDescriptionYellow from './ColorDescriptionYellow.svelte';
+	import ColorDescriptionGreen from './ColorDescriptionGreen.svelte';
+	import ColorDescriptionBlue from './ColorDescriptionBlue.svelte';
+	import ColorDescriptionIndigo from './ColorDescriptionIndigo.svelte';
+	import ColorDescriptionViolet from './ColorDescriptionViolet.svelte';
+	import ColorDescriptionMagenta from './ColorDescriptionMagenta.svelte';
+	import ColorDescriptionWhite from './ColorDescriptionWhite.svelte';
+	import ColorDescriptionBlack from './ColorDescriptionBlack.svelte';
 
 	import AgeDescriptionWyrmling from './AgeDescriptionWyrmling.svelte';
+	import AgeDescriptionYoung from './AgeDescriptionYoung.svelte';
+	import AgeDescriptionAdult from './AgeDescriptionAdult.svelte';
+	import AgeDescriptionAncient from './AgeDescriptionAncient.svelte';
+	import AgeDescriptionCosmic from './AgeDescriptionCosmic.svelte';
 
 	export let config: DragonConfig | undefined;
 </script>
 
 {#if config !== undefined}
 	<div>
-		{#if config?.color === 'red'}
+		{#if config.color === 'red'}
 			<ColorDescriptionRed />
+		{:else if config.color === 'orange'}
+			<ColorDescriptionOrange />
+		{:else if config.color === 'yellow'}
+			<ColorDescriptionYellow />
+		{:else if config.color === 'green'}
+			<ColorDescriptionGreen />
+		{:else if config.color === 'blue'}
+			<ColorDescriptionBlue />
+		{:else if config.color === 'indigo'}
+			<ColorDescriptionIndigo />
+		{:else if config.color === 'violet'}
+			<ColorDescriptionViolet />
+		{:else if config.color === 'magenta'}
+			<ColorDescriptionMagenta />
+		{:else if config.color === 'white'}
+			<ColorDescriptionWhite />
+		{:else if config.color === 'black'}
+			<ColorDescriptionBlack />
 		{/if}
 	</div>
 
 	<div class="mt-2">
-		{#if config?.age === 'wyrmling'}
+		{#if config.age === 'wyrmling'}
 			<AgeDescriptionWyrmling />
+		{:else if config.age === 'young'}
+			<AgeDescriptionYoung />
+		{:else if config.age === 'adult'}
+			<AgeDescriptionAdult />
+		{:else if config.age === 'ancient'}
+			<AgeDescriptionAncient />
+		{:else if config.age === 'cosmic'}
+			<AgeDescriptionCosmic />
 		{/if}
 	</div>
 {/if}

--- a/src/lib/dragon/dragon-config.ts
+++ b/src/lib/dragon/dragon-config.ts
@@ -22,6 +22,7 @@ import {
 import type { Size, ProficiencyLevel } from '$lib/monsters';
 import { stringToSize, ABILITIES, SKILLS } from '$lib/monsters';
 
+import { BASE_SHARE_URL } from '$lib';
 import { capitalizeFirstLetter, type RGB } from '$lib/text-utils';
 
 export class DragonConfig {
@@ -119,6 +120,10 @@ export class DragonConfig {
 	 */
 	get theme(): RGB {
 		return COLOR_TO_THEME[this.color];
+	}
+
+	get url(): string {
+		return `${BASE_SHARE_URL}?${this.toString()}`;
 	}
 
 	/**

--- a/src/lib/dragon/stat-block/lair-actions/DragonLairActions.svelte
+++ b/src/lib/dragon/stat-block/lair-actions/DragonLairActions.svelte
@@ -9,7 +9,8 @@
 	<div class="mb-2">
 		<h5 class="font-bold text-base">Lair Actions</h5>
 		<p>
-			{dragon.nameUpper} has lair actions.
+			{dragon.nameUpper} will have lair actions once they are written. For now, this section is only
+			visible while in development mode.
 		</p>
 	</div>
 {/if}

--- a/src/lib/dragon/stat-block/lair-actions/DragonLairActions.svelte
+++ b/src/lib/dragon/stat-block/lair-actions/DragonLairActions.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { LAIR_ACTIONS_ENABLED } from '.';
+	import type { DragonStats } from '$lib/dragon/dragon-stats';
+
+	export let dragon: DragonStats;
+</script>
+
+{#if dragon.age !== 'wyrmling' && dragon.age !== 'young' && LAIR_ACTIONS_ENABLED}
+	<div class="mb-2">
+		<h5 class="font-bold text-base">Lair Actions</h5>
+		<p>
+			{dragon.nameUpper} has lair actions.
+		</p>
+	</div>
+{/if}

--- a/src/lib/dragon/stat-block/lair-actions/index.ts
+++ b/src/lib/dragon/stat-block/lair-actions/index.ts
@@ -1,0 +1,3 @@
+import { dev } from '$app/environment';
+
+export const LAIR_ACTIONS_ENABLED = true && dev;

--- a/src/lib/modals/DragonShareModal.svelte
+++ b/src/lib/modals/DragonShareModal.svelte
@@ -11,8 +11,7 @@
 	export let parent: SkeletonModalParentType;
 
 	let shareInfo: DragonShareModalValue = $modalStore[0].value;
-	let shareURL =
-		shareInfo.dragon === undefined ? BASE_SHARE_URL : `${BASE_SHARE_URL}?${shareInfo.dragon}`;
+	let shareURL = shareInfo.dragon === undefined ? BASE_SHARE_URL : shareInfo.dragon.url;
 
 	onDestroy(() => {
 		if (shareInfo.onDestroyFocusElement !== undefined) {

--- a/src/lib/monsters/MonsterHeading.svelte
+++ b/src/lib/monsters/MonsterHeading.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	export let source = '';
+</script>
+
+{#if $$slots.default}
+	<div class="mb-2">
+		<h1 class="monster-name"><slot /></h1>
+		{#if source.length > 0}
+			<p><b>Source:</b> {source}</p>
+		{/if}
+	</div>
+{/if}

--- a/src/lib/monsters/MonsterLink.svelte
+++ b/src/lib/monsters/MonsterLink.svelte
@@ -13,6 +13,7 @@
 	};
 
 	export let monster: AppMonster;
+	export let monsterText: string | undefined = undefined;
 	export let disabled = false;
 
 	let thisElement: HTMLElement | undefined;
@@ -27,4 +28,4 @@
 	}
 </script>
 
-<SpanButton {disabled} on:click={handleClick} bind:thisElement>{monster}</SpanButton>
+<SpanButton {disabled} on:click={handleClick} bind:thisElement>{monsterText ?? monster}</SpanButton>

--- a/src/lib/monsters/index.ts
+++ b/src/lib/monsters/index.ts
@@ -1,14 +1,18 @@
 import type { ComponentType } from 'svelte';
 
-import { PETAL_MONSTERS } from './petal-monsters';
+import { PETAL_MONSTERS, PETAL_MONSTER_TITLES } from './petal-monsters';
 import { PETAL_MONSTER_STAT_BLOCKS } from './petal-monsters/petal-monster-stat-blocks';
 
-import { SRD_MONSTERS } from './srd-monsters';
+import { SRD_MONSTERS, SRD_MONSTER_TITLES } from './srd-monsters';
 import { SRD_MONSTER_STAT_BLOCKS } from './srd-monsters/srd-monster-stat-blocks';
 
 export const APP_MONSTERS = [...PETAL_MONSTERS, ...SRD_MONSTERS] as const;
 
 export type AppMonster = (typeof APP_MONSTERS)[number];
+
+export const APP_MONSTER_TITLES: {
+	[key in AppMonster]: string;
+} = { ...PETAL_MONSTER_TITLES, ...SRD_MONSTER_TITLES } as const;
 
 export const APP_MONSTER_STAT_BLOCKS: {
 	[key in AppMonster]: ComponentType;

--- a/src/lib/monsters/monster-vals.ts
+++ b/src/lib/monsters/monster-vals.ts
@@ -87,7 +87,7 @@ export function getPassivePerception(
 	wisdomMod: number,
 	proficiencies?: SkillProficiencies
 ): number {
-	let output = 8 + wisdomMod;
+	let output = 10 + wisdomMod;
 	if (
 		proficiencies !== undefined &&
 		proficiencies.skillPerception !== undefined &&

--- a/src/lib/monsters/petal-monsters/StaticDragonStatBlock.svelte
+++ b/src/lib/monsters/petal-monsters/StaticDragonStatBlock.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import type { Age, Color } from '$lib/dragon';
+	import { DragonConfig } from '$lib/dragon/dragon-config';
+
+	import MonsterHeading from '$lib/monsters/MonsterHeading.svelte';
+	import StatBlockContainer from '$lib/stat-block/StatBlockContainer.svelte';
+	import DragonStatBlock from '$lib/dragon/stat-block/DragonStatBlock.svelte';
+
+	export let age: Age;
+	export let color: Color;
+
+	const config: DragonConfig = new DragonConfig();
+	$: config.age = age;
+	$: config.color = color;
+</script>
+
+<div class="mx-auto">
+	<MonsterHeading source="Petal Quest">{config.title}</MonsterHeading>
+
+	<StatBlockContainer theme={config.theme}>
+		<DragonStatBlock {config} />
+	</StatBlockContainer>
+
+	{#if $$slots.default}
+		<div class="mt-4">
+			<slot />
+		</div>
+	{/if}
+</div>

--- a/src/lib/monsters/petal-monsters/StaticDragonStatBlock.svelte
+++ b/src/lib/monsters/petal-monsters/StaticDragonStatBlock.svelte
@@ -24,7 +24,7 @@
 
 	<div class="mt-4">
 		<slot />
-		<DragonDescription {age} {color} />
+		<DragonDescription {config} />
 	</div>
 
 	<div class="max-w-xl w-fit mx-auto">

--- a/src/lib/monsters/petal-monsters/StaticDragonStatBlock.svelte
+++ b/src/lib/monsters/petal-monsters/StaticDragonStatBlock.svelte
@@ -5,6 +5,7 @@
 	import MonsterHeading from '$lib/monsters/MonsterHeading.svelte';
 	import StatBlockContainer from '$lib/stat-block/StatBlockContainer.svelte';
 	import DragonStatBlock from '$lib/dragon/stat-block/DragonStatBlock.svelte';
+	import DragonDescription from '$lib/dragon/descriptions/DragonDescription.svelte';
 
 	export let age: Age;
 	export let color: Color;
@@ -21,9 +22,14 @@
 		<DragonStatBlock {config} />
 	</StatBlockContainer>
 
-	{#if $$slots.default}
-		<div class="mt-4">
-			<slot />
-		</div>
-	{/if}
+	<div class="mt-4">
+		<slot />
+		<DragonDescription {age} {color} />
+	</div>
+
+	<div class="max-w-xl w-fit mx-auto">
+		<a href={`/dragon-builder/?${config}`} class="daisy-btn daisy-btn-neutral !text-white mt-4"
+			>Edit in the Dragon Builder</a
+		>
+	</div>
 </div>

--- a/src/lib/monsters/petal-monsters/index.ts
+++ b/src/lib/monsters/petal-monsters/index.ts
@@ -1,4 +1,64 @@
-export const PETAL_MONSTERS = ['red-dragon-wyrmling'] as const;
+export const PETAL_MONSTERS = [
+	'red-dragon-wyrmling',
+	'young-red-dragon',
+	'adult-red-dragon',
+	'ancient-red-dragon',
+	'cosmic-red-dragon',
+
+	'orange-dragon-wyrmling',
+	'young-orange-dragon',
+	'adult-orange-dragon',
+	'ancient-orange-dragon',
+	'cosmic-orange-dragon',
+
+	'yellow-dragon-wyrmling',
+	'young-yellow-dragon',
+	'adult-yellow-dragon',
+	'ancient-yellow-dragon',
+	'cosmic-yellow-dragon',
+
+	'green-dragon-wyrmling',
+	'young-green-dragon',
+	'adult-green-dragon',
+	'ancient-green-dragon',
+	'cosmic-green-dragon',
+
+	'blue-dragon-wyrmling',
+	'young-blue-dragon',
+	'adult-blue-dragon',
+	'ancient-blue-dragon',
+	'cosmic-blue-dragon',
+
+	'indigo-dragon-wyrmling',
+	'young-indigo-dragon',
+	'adult-indigo-dragon',
+	'ancient-indigo-dragon',
+	'cosmic-indigo-dragon',
+
+	'violet-dragon-wyrmling',
+	'young-violet-dragon',
+	'adult-violet-dragon',
+	'ancient-violet-dragon',
+	'cosmic-violet-dragon',
+
+	'magenta-dragon-wyrmling',
+	'young-magenta-dragon',
+	'adult-magenta-dragon',
+	'ancient-magenta-dragon',
+	'cosmic-magenta-dragon',
+
+	'white-dragon-wyrmling',
+	'young-white-dragon',
+	'adult-white-dragon',
+	'ancient-white-dragon',
+	'cosmic-white-dragon',
+
+	'black-dragon-wyrmling',
+	'young-black-dragon',
+	'adult-black-dragon',
+	'ancient-black-dragon',
+	'cosmic-black-dragon'
+] as const;
 
 export type PetalMonster = (typeof PETAL_MONSTERS)[number];
 
@@ -15,5 +75,63 @@ export function stringToPetalMonster(monsterString: string): PetalMonster | unde
 export const PETAL_MONSTER_TITLES: {
 	[key in PetalMonster]: string;
 } = {
-	'red-dragon-wyrmling': 'Red Dragon Wyrmling'
+	'red-dragon-wyrmling': 'Red Dragon Wyrmling',
+	'young-red-dragon': 'Young Red Dragon',
+	'adult-red-dragon': 'Adult Red Dragon',
+	'ancient-red-dragon': 'Ancient Red Dragon',
+	'cosmic-red-dragon': 'Cosmic Red Dragon',
+
+	'orange-dragon-wyrmling': 'Orange Dragon Wyrmling',
+	'young-orange-dragon': 'Young Orange Dragon',
+	'adult-orange-dragon': 'Adult Orange Dragon',
+	'ancient-orange-dragon': 'Ancient Orange Dragon',
+	'cosmic-orange-dragon': 'Cosmic Orange Dragon',
+
+	'yellow-dragon-wyrmling': 'Yellow Dragon Wyrmling',
+	'young-yellow-dragon': 'Young Yellow Dragon',
+	'adult-yellow-dragon': 'Adult Yellow Dragon',
+	'ancient-yellow-dragon': 'Ancient Yellow Dragon',
+	'cosmic-yellow-dragon': 'Cosmic Yellow Dragon',
+
+	'green-dragon-wyrmling': 'Green Dragon Wyrmling',
+	'young-green-dragon': 'Young Green Dragon',
+	'adult-green-dragon': 'Adult Green Dragon',
+	'ancient-green-dragon': 'Ancient Green Dragon',
+	'cosmic-green-dragon': 'Cosmic Green Dragon',
+
+	'blue-dragon-wyrmling': 'Blue Dragon Wyrmling',
+	'young-blue-dragon': 'Young Blue Dragon',
+	'adult-blue-dragon': 'Adult Blue Dragon',
+	'ancient-blue-dragon': 'Ancient Blue Dragon',
+	'cosmic-blue-dragon': 'Cosmic Blue Dragon',
+
+	'indigo-dragon-wyrmling': 'Indigo Dragon Wyrmling',
+	'young-indigo-dragon': 'Young Indigo Dragon',
+	'adult-indigo-dragon': 'Adult Indigo Dragon',
+	'ancient-indigo-dragon': 'Ancient Indigo Dragon',
+	'cosmic-indigo-dragon': 'Cosmic Indigo Dragon',
+
+	'violet-dragon-wyrmling': 'Violet Dragon Wyrmling',
+	'young-violet-dragon': 'Young Violet Dragon',
+	'adult-violet-dragon': 'Adult Violet Dragon',
+	'ancient-violet-dragon': 'Ancient Violet Dragon',
+	'cosmic-violet-dragon': 'Cosmic Violet Dragon',
+
+	'magenta-dragon-wyrmling': 'Magenta Dragon Wyrmling',
+	'young-magenta-dragon': 'Young Magenta Dragon',
+	'adult-magenta-dragon': 'Adult Magenta Dragon',
+	'ancient-magenta-dragon': 'Ancient Magenta Dragon',
+	'cosmic-magenta-dragon': 'Cosmic Magenta Dragon',
+
+	'white-dragon-wyrmling': 'White Dragon Wyrmling',
+	'young-white-dragon': 'Young White Dragon',
+	'adult-white-dragon': 'Adult White Dragon',
+	'ancient-white-dragon': 'Ancient White Dragon',
+	'cosmic-white-dragon': 'Cosmic White Dragon',
+
+	'black-dragon-wyrmling': 'Black Dragon Wyrmling',
+	'young-black-dragon': 'Young Black Dragon',
+	'adult-black-dragon': 'Adult Black Dragon',
+	'ancient-black-dragon': 'Ancient Black Dragon',
+	'cosmic-black-dragon': 'Cosmic Black Dragon'
 } as const;

--- a/src/lib/monsters/petal-monsters/index.ts
+++ b/src/lib/monsters/petal-monsters/index.ts
@@ -1,4 +1,4 @@
-export const PETAL_MONSTERS = [] as const;
+export const PETAL_MONSTERS = ['red-dragon-wyrmling'] as const;
 
 export type PetalMonster = (typeof PETAL_MONSTERS)[number];
 
@@ -11,3 +11,9 @@ export type PetalMonster = (typeof PETAL_MONSTERS)[number];
 export function stringToPetalMonster(monsterString: string): PetalMonster | undefined {
 	return PETAL_MONSTERS.find((monster) => monster === monsterString);
 }
+
+export const PETAL_MONSTER_TITLES: {
+	[key in PetalMonster]: string;
+} = {
+	'red-dragon-wyrmling': 'Red Dragon Wyrmling'
+} as const;

--- a/src/lib/monsters/petal-monsters/petal-monster-stat-blocks.ts
+++ b/src/lib/monsters/petal-monsters/petal-monster-stat-blocks.ts
@@ -2,6 +2,10 @@ import type { ComponentType } from 'svelte';
 
 import type { PetalMonster } from '.';
 
+import StatBlockPrismaticRedWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticRedWyrmling.svelte';
+
 export const PETAL_MONSTER_STAT_BLOCKS: {
 	[key in PetalMonster]: ComponentType;
-} = {} as const;
+} = {
+	'red-dragon-wyrmling': StatBlockPrismaticRedWyrmling__SvelteComponent_
+} as const;

--- a/src/lib/monsters/petal-monsters/petal-monster-stat-blocks.ts
+++ b/src/lib/monsters/petal-monsters/petal-monster-stat-blocks.ts
@@ -3,9 +3,125 @@ import type { ComponentType } from 'svelte';
 import type { PetalMonster } from '.';
 
 import StatBlockPrismaticRedWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticRedWyrmling.svelte';
+import StatBlockPrismaticRedYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticRedYoung.svelte';
+import StatBlockPrismaticRedAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticRedAdult.svelte';
+import StatBlockPrismaticRedAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticRedAncient.svelte';
+import StatBlockPrismaticRedCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticRedCosmic.svelte';
+
+import StatBlockPrismaticOrangeWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticOrangeWyrmling.svelte';
+import StatBlockPrismaticOrangeYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticOrangeYoung.svelte';
+import StatBlockPrismaticOrangeAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticOrangeAdult.svelte';
+import StatBlockPrismaticOrangeAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticOrangeAncient.svelte';
+import StatBlockPrismaticOrangeCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticOrangeCosmic.svelte';
+
+import StatBlockPrismaticYellowWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticYellowWyrmling.svelte';
+import StatBlockPrismaticYellowYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticYellowYoung.svelte';
+import StatBlockPrismaticYellowAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticYellowAdult.svelte';
+import StatBlockPrismaticYellowAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticYellowAncient.svelte';
+import StatBlockPrismaticYellowCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticYellowCosmic.svelte';
+
+import StatBlockPrismaticGreenWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticGreenWyrmling.svelte';
+import StatBlockPrismaticGreenYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticGreenYoung.svelte';
+import StatBlockPrismaticGreenAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticGreenAdult.svelte';
+import StatBlockPrismaticGreenAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticGreenAncient.svelte';
+import StatBlockPrismaticGreenCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticGreenCosmic.svelte';
+
+import StatBlockPrismaticBlueWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlueWyrmling.svelte';
+import StatBlockPrismaticBlueYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlueYoung.svelte';
+import StatBlockPrismaticBlueAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlueAdult.svelte';
+import StatBlockPrismaticBlueAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlueAncient.svelte';
+import StatBlockPrismaticBlueCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlueCosmic.svelte';
+
+import StatBlockPrismaticIndigoWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticIndigoWyrmling.svelte';
+import StatBlockPrismaticIndigoYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticIndigoYoung.svelte';
+import StatBlockPrismaticIndigoAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticIndigoAdult.svelte';
+import StatBlockPrismaticIndigoAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticIndigoAncient.svelte';
+import StatBlockPrismaticIndigoCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticIndigoCosmic.svelte';
+
+import StatBlockPrismaticVioletWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticVioletWyrmling.svelte';
+import StatBlockPrismaticVioletYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticVioletYoung.svelte';
+import StatBlockPrismaticVioletAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticVioletAdult.svelte';
+import StatBlockPrismaticVioletAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticVioletAncient.svelte';
+import StatBlockPrismaticVioletCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticVioletCosmic.svelte';
+
+import StatBlockPrismaticMagentaWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticMagentaWyrmling.svelte';
+import StatBlockPrismaticMagentaYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticMagentaYoung.svelte';
+import StatBlockPrismaticMagentaAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticMagentaAdult.svelte';
+import StatBlockPrismaticMagentaAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticMagentaAncient.svelte';
+import StatBlockPrismaticMagentaCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticMagentaCosmic.svelte';
+
+import StatBlockPrismaticWhiteWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticWhiteWyrmling.svelte';
+import StatBlockPrismaticWhiteYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticWhiteYoung.svelte';
+import StatBlockPrismaticWhiteAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticWhiteAdult.svelte';
+import StatBlockPrismaticWhiteAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticWhiteAncient.svelte';
+import StatBlockPrismaticWhiteCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticWhiteCosmic.svelte';
+
+import StatBlockPrismaticBlackWyrmling__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlackWyrmling.svelte';
+import StatBlockPrismaticBlackYoung__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlackYoung.svelte';
+import StatBlockPrismaticBlackAdult__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlackAdult.svelte';
+import StatBlockPrismaticBlackAncient__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlackAncient.svelte';
+import StatBlockPrismaticBlackCosmic__SvelteComponent_ from './stat-blocks/StatBlock__PrismaticBlackCosmic.svelte';
 
 export const PETAL_MONSTER_STAT_BLOCKS: {
 	[key in PetalMonster]: ComponentType;
 } = {
-	'red-dragon-wyrmling': StatBlockPrismaticRedWyrmling__SvelteComponent_
+	'red-dragon-wyrmling': StatBlockPrismaticRedWyrmling__SvelteComponent_,
+	'young-red-dragon': StatBlockPrismaticRedYoung__SvelteComponent_,
+	'adult-red-dragon': StatBlockPrismaticRedAdult__SvelteComponent_,
+	'ancient-red-dragon': StatBlockPrismaticRedAncient__SvelteComponent_,
+	'cosmic-red-dragon': StatBlockPrismaticRedCosmic__SvelteComponent_,
+
+	'orange-dragon-wyrmling': StatBlockPrismaticOrangeWyrmling__SvelteComponent_,
+	'young-orange-dragon': StatBlockPrismaticOrangeYoung__SvelteComponent_,
+	'adult-orange-dragon': StatBlockPrismaticOrangeAdult__SvelteComponent_,
+	'ancient-orange-dragon': StatBlockPrismaticOrangeAncient__SvelteComponent_,
+	'cosmic-orange-dragon': StatBlockPrismaticOrangeCosmic__SvelteComponent_,
+
+	'yellow-dragon-wyrmling': StatBlockPrismaticYellowWyrmling__SvelteComponent_,
+	'young-yellow-dragon': StatBlockPrismaticYellowYoung__SvelteComponent_,
+	'adult-yellow-dragon': StatBlockPrismaticYellowAdult__SvelteComponent_,
+	'ancient-yellow-dragon': StatBlockPrismaticYellowAncient__SvelteComponent_,
+	'cosmic-yellow-dragon': StatBlockPrismaticYellowCosmic__SvelteComponent_,
+
+	'green-dragon-wyrmling': StatBlockPrismaticGreenWyrmling__SvelteComponent_,
+	'young-green-dragon': StatBlockPrismaticGreenYoung__SvelteComponent_,
+	'adult-green-dragon': StatBlockPrismaticGreenAdult__SvelteComponent_,
+	'ancient-green-dragon': StatBlockPrismaticGreenAncient__SvelteComponent_,
+	'cosmic-green-dragon': StatBlockPrismaticGreenCosmic__SvelteComponent_,
+
+	'blue-dragon-wyrmling': StatBlockPrismaticBlueWyrmling__SvelteComponent_,
+	'young-blue-dragon': StatBlockPrismaticBlueYoung__SvelteComponent_,
+	'adult-blue-dragon': StatBlockPrismaticBlueAdult__SvelteComponent_,
+	'ancient-blue-dragon': StatBlockPrismaticBlueAncient__SvelteComponent_,
+	'cosmic-blue-dragon': StatBlockPrismaticBlueCosmic__SvelteComponent_,
+
+	'indigo-dragon-wyrmling': StatBlockPrismaticIndigoWyrmling__SvelteComponent_,
+	'young-indigo-dragon': StatBlockPrismaticIndigoYoung__SvelteComponent_,
+	'adult-indigo-dragon': StatBlockPrismaticIndigoAdult__SvelteComponent_,
+	'ancient-indigo-dragon': StatBlockPrismaticIndigoAncient__SvelteComponent_,
+	'cosmic-indigo-dragon': StatBlockPrismaticIndigoCosmic__SvelteComponent_,
+
+	'violet-dragon-wyrmling': StatBlockPrismaticVioletWyrmling__SvelteComponent_,
+	'young-violet-dragon': StatBlockPrismaticVioletYoung__SvelteComponent_,
+	'adult-violet-dragon': StatBlockPrismaticVioletAdult__SvelteComponent_,
+	'ancient-violet-dragon': StatBlockPrismaticVioletAncient__SvelteComponent_,
+	'cosmic-violet-dragon': StatBlockPrismaticVioletCosmic__SvelteComponent_,
+
+	'magenta-dragon-wyrmling': StatBlockPrismaticMagentaWyrmling__SvelteComponent_,
+	'young-magenta-dragon': StatBlockPrismaticMagentaYoung__SvelteComponent_,
+	'adult-magenta-dragon': StatBlockPrismaticMagentaAdult__SvelteComponent_,
+	'ancient-magenta-dragon': StatBlockPrismaticMagentaAncient__SvelteComponent_,
+	'cosmic-magenta-dragon': StatBlockPrismaticMagentaCosmic__SvelteComponent_,
+
+	'white-dragon-wyrmling': StatBlockPrismaticWhiteWyrmling__SvelteComponent_,
+	'young-white-dragon': StatBlockPrismaticWhiteYoung__SvelteComponent_,
+	'adult-white-dragon': StatBlockPrismaticWhiteAdult__SvelteComponent_,
+	'ancient-white-dragon': StatBlockPrismaticWhiteAncient__SvelteComponent_,
+	'cosmic-white-dragon': StatBlockPrismaticWhiteCosmic__SvelteComponent_,
+
+	'black-dragon-wyrmling': StatBlockPrismaticBlackWyrmling__SvelteComponent_,
+	'young-black-dragon': StatBlockPrismaticBlackYoung__SvelteComponent_,
+	'adult-black-dragon': StatBlockPrismaticBlackAdult__SvelteComponent_,
+	'ancient-black-dragon': StatBlockPrismaticBlackAncient__SvelteComponent_,
+	'cosmic-black-dragon': StatBlockPrismaticBlackCosmic__SvelteComponent_
 } as const;

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="black" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="black" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="black" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackWyrmling.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="black" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlackYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="black" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="blue" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="blue" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="blue" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueWyrmling.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="blue" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticBlueYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="blue" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="green" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="green" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="green" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenWyrmling.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="green" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticGreenYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="green" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="indigo" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="indigo" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="indigo" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoWyrmling.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="indigo" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticIndigoYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="indigo" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="magenta" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="magenta" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="magenta" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaWyrmling.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="magenta" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticMagentaYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="magenta" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="orange" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="orange" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="orange" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeWyrmling.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="orange" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticOrangeYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="orange" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="red" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="red" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="red" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedWyrmling.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="red">
+	<p>This is the static version of this stat block.</p>
+</StaticDragonStatBlock>

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedWyrmling.svelte
@@ -2,6 +2,4 @@
 	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
 </script>
 
-<StaticDragonStatBlock age="wyrmling" color="red">
-	<p>This is the static version of this stat block.</p>
-</StaticDragonStatBlock>
+<StaticDragonStatBlock age="wyrmling" color="red" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticRedYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="red" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="violet" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="violet" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="violet" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletWyrmling.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="violet" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticVioletYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="violet" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="white" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="white" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="white" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteWyrmling.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="white" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticWhiteYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="white" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowAdult.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowAdult.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="adult" color="yellow" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowAncient.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowAncient.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="ancient" color="yellow" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowCosmic.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowCosmic.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="cosmic" color="yellow" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowWyrmling.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowWyrmling.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="wyrmling" color="yellow" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowYoung.svelte
+++ b/src/lib/monsters/petal-monsters/stat-blocks/StatBlock__PrismaticYellowYoung.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import StaticDragonStatBlock from '../StaticDragonStatBlock.svelte';
+</script>
+
+<StaticDragonStatBlock age="young" color="yellow" />

--- a/src/lib/monsters/petal-monsters/stat-blocks/duplicator.py
+++ b/src/lib/monsters/petal-monsters/stat-blocks/duplicator.py
@@ -1,0 +1,19 @@
+files_to_dupe = [
+    "StatBlock__PrismaticRedAdult.svelte", "StatBlock__PrismaticRedAncient.svelte",
+    "StatBlock__PrismaticRedCosmic.svelte", "StatBlock__PrismaticRedWyrmling.svelte", "StatBlock__PrismaticRedYoung.svelte",
+]
+
+colors_to_make = [
+    "Yellow", "Green", "Blue",
+    "Indigo", "Violet", "Magenta", "White", "Black"
+]
+
+for file in files_to_dupe:
+    file_text = ""
+    with open(file, 'r') as fp:
+        file_text = fp.read()
+    for color in colors_to_make:
+        new_file_name = file.replace('Red', color)
+        new_file_text = file_text.replace('red', color.lower())
+        with open(new_file_name, 'w') as fp:
+            fp.write(new_file_text)

--- a/src/lib/monsters/srd-monsters/index.ts
+++ b/src/lib/monsters/srd-monsters/index.ts
@@ -11,3 +11,9 @@ export type SRDMonster = (typeof SRD_MONSTERS)[number];
 export function stringToSRDMonster(monsterString: string): SRDMonster | undefined {
 	return SRD_MONSTERS.find((monster) => monster === monsterString);
 }
+
+export const SRD_MONSTER_TITLES: {
+	[key in SRDMonster]: string;
+} = {
+	frog: 'Frog'
+} as const;

--- a/src/lib/monsters/srd-monsters/srd-monster-vals.ts
+++ b/src/lib/monsters/srd-monsters/srd-monster-vals.ts
@@ -1,11 +1,12 @@
 import type { SRDMonster } from '.';
+import { SRD_MONSTER_TITLES } from '.';
 import type { MonsterVals } from '../monster-vals';
 
 export const SRD_MONSTER_VALS: {
 	[key in SRDMonster]: MonsterVals;
 } = {
 	frog: {
-		title: 'Frog',
+		title: SRD_MONSTER_TITLES['frog'],
 		size: 'Tiny',
 		type: 'beast',
 		alignment: 'unaligned',

--- a/src/lib/monsters/srd-monsters/stat-blocks/StatBlockFrog.svelte
+++ b/src/lib/monsters/srd-monsters/stat-blocks/StatBlockFrog.svelte
@@ -2,6 +2,7 @@
 	import { SRD_MONSTER_VALS } from '../srd-monster-vals';
 	import { statsFromMonsterVals } from '../../monster-vals';
 
+	import MonsterHeading from '$lib/monsters/MonsterHeading.svelte';
 	import StatBlockContainer from '$lib/stat-block/StatBlockContainer.svelte';
 	import StatBlockContents from '$lib/stat-block/StatBlockContents.svelte';
 
@@ -9,10 +10,7 @@
 </script>
 
 <div class="max-w-xl mx-auto">
-	<div class="mb-2">
-		<h1 class="monster-name">Frog</h1>
-		<p><b>Source:</b> SRD 5.1</p>
-	</div>
+	<MonsterHeading source="SRD 5.1">Frog</MonsterHeading>
 
 	<StatBlockContainer theme={stats.theme}>
 		<StatBlockContents {stats}>

--- a/src/routes/monsters/+page.svelte
+++ b/src/routes/monsters/+page.svelte
@@ -11,7 +11,7 @@
 
 <PageMeta
 	title="Monsters - Petal Quest"
-	description="Monsters for 5th edition, from the SRD."
+	description="Monsters for 5th edition, both homebrew and from the SRD."
 	url="https://www.petalquest.com/monsters/"
 />
 

--- a/src/routes/monsters/+page.svelte
+++ b/src/routes/monsters/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { SRD_MONSTERS } from '$lib/monsters/srd-monsters';
-	import { capitalizeFirstLetter } from '$lib/text-utils';
+	import { PETAL_MONSTERS, PETAL_MONSTER_TITLES } from '$lib/monsters/petal-monsters';
+	import { SRD_MONSTERS, SRD_MONSTER_TITLES } from '$lib/monsters/srd-monsters';
 
 	import PageMeta from '$lib/PageMeta.svelte';
 
@@ -15,12 +15,22 @@
 	url="https://www.petalquest.com/monsters/"
 />
 
+<h2 class="mt-4">Homebrew Monsters</h2>
+
+<ul>
+	{#each PETAL_MONSTERS as monster}
+		<li>
+			<a href={getMonsterURL(monster)}>{PETAL_MONSTER_TITLES[monster]}</a>
+		</li>
+	{/each}
+</ul>
+
 <h2 class="mt-4">SRD Monsters</h2>
 
 <ul>
 	{#each SRD_MONSTERS as monster}
 		<li>
-			<a href={getMonsterURL(monster)}>{capitalizeFirstLetter(monster)}</a>
+			<a href={getMonsterURL(monster)}>{SRD_MONSTER_TITLES[monster]}</a>
 		</li>
 	{/each}
 </ul>

--- a/src/routes/monsters/[monster]/+page.svelte
+++ b/src/routes/monsters/[monster]/+page.svelte
@@ -11,7 +11,7 @@
 
 <PageMeta
 	title={`${APP_MONSTER_TITLES[data.monster]} - Monsters - Petal Quest`}
-	description="Monsters for 5th edition, from the SRD."
+	description="Monsters for 5th edition, both homebrew and from the SRD."
 	url={`https://www.petalquest.com/monsters/${data.monster}/`}
 />
 

--- a/src/routes/monsters/[monster]/+page.svelte
+++ b/src/routes/monsters/[monster]/+page.svelte
@@ -1,17 +1,16 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 
-	import { APP_MONSTER_STAT_BLOCKS } from '$lib/monsters';
-	import MonsterCard from '$lib/monsters/MonsterCard.svelte';
+	import { APP_MONSTER_TITLES } from '$lib/monsters';
 
+	import MonsterCard from '$lib/monsters/MonsterCard.svelte';
 	import PageMeta from '$lib/PageMeta.svelte';
-	import { capitalizeFirstLetter } from '$lib/text-utils';
 
 	export let data: PageData;
 </script>
 
 <PageMeta
-	title={`${capitalizeFirstLetter(data.monster)} - Monsters - Petal Quest`}
+	title={`${APP_MONSTER_TITLES[data.monster]} - Monsters - Petal Quest`}
 	description="Monsters for 5th edition, from the SRD."
 	url={`https://www.petalquest.com/monsters/${data.monster}/`}
 />


### PR DESCRIPTION
## What's in this PR?
This PR adds a static stat block page for each age/color of prismatic dragon. Honestly this wasn't really necessary, but I thought it'd be nice to have multiple dragon stat blocks open without having the full interactivity of the Dragon Builder.

I also added descriptions for each age and color. The color descriptions are copied from [my PalladiumTurtle website](https://www.palladiumturtle.com/dragons/colors). I edited the red dragon one slightly to remove the mention of the enchanting effect that red dragons no longer do.

When lair actions are added, they'll appear below the stat block and above the description. Right now, there's a placeholder description which is visible only in development mode.

## 🐢
