### PR TITLE
Small Bug Fixes + Minor Wording Changes

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -189,16 +189,6 @@ body {
 	}
 }
 
-#page {
-	scroll-behavior: smooth;
-}
-
-@media (prefers-reduced-motion) {
-	#page {
-		scroll-behavior: auto;
-	}
-}
-
 .tree-item-content {
 	/* Workaround until Skeleton allows custom TreeViewItem width */
 	@apply w-full;

--- a/src/lib/dragon/dragon-stats.ts
+++ b/src/lib/dragon/dragon-stats.ts
@@ -1,4 +1,4 @@
-import type { Age, Color, PronounsConfig } from '.';
+import type { Age, Color, PronounsConfig, PronounsExistence } from '.';
 import {
 	COLOR_TO_ALIGNMENT,
 	AGE_TO_SIZE,
@@ -59,11 +59,14 @@ export class DragonStats {
 		this.title = this.#config.title;
 		this.alignment = this.#config.alignment ?? COLOR_TO_ALIGNMENT[this.color];
 
-		const pronouns = this.#getPronounsConfig();
+		const pronouns = this.#getPronouns();
 		this.pronounsPlural = pronouns.plural;
 		this.pronounNominative = pronouns.nominative;
+		this.pronounNominativeExists = pronouns.nominativeExists;
 		this.pronounObjective = pronouns.objective;
+		this.pronounObjectiveExists = pronouns.objectiveExists;
 		this.pronounPossessiveAdjective = pronouns.possessiveAdjective;
+		this.pronounPossessiveAdjectiveExists = pronouns.possessiveAdjectiveExists;
 
 		this.size = this.#getSize();
 		this.type = this.#getType();
@@ -244,15 +247,23 @@ export class DragonStats {
 		}
 	}
 
-	#getPronounsConfig(): PronounsConfig {
-		const nonePronounsConfig: PronounsConfig = {
+	#getPronouns(): PronounsConfig & PronounsExistence {
+		const nonePronounsConfig: PronounsConfig & PronounsExistence = {
 			plural: false,
 			nominative: this.name,
+			nominativeExists: false,
 			objective: this.name,
-			possessiveAdjective: `${this.name}'s`
+			objectiveExists: false,
+			possessiveAdjective: `${this.name}'s`,
+			possessiveAdjectiveExists: false
+		};
+		const pronounsExist: PronounsExistence = {
+			nominativeExists: true,
+			objectiveExists: true,
+			possessiveAdjectiveExists: true
 		};
 		if (this.#config.pronouns === undefined || this.#config.pronouns === DEFAULT_PRONOUNS) {
-			return BASIC_PRONOUN_CONFIGS[DEFAULT_PRONOUNS];
+			return { ...BASIC_PRONOUN_CONFIGS[DEFAULT_PRONOUNS], ...pronounsExist };
 		} else if (this.#config.pronouns === 'none') {
 			return nonePronounsConfig;
 		} else if (this.#config.pronouns === 'custom') {
@@ -262,18 +273,21 @@ export class DragonStats {
 				customPronounsConfig.plural = this.#config.pronounsConfig.plural;
 				if (this.#config.pronounsConfig.nominative !== '') {
 					customPronounsConfig.nominative = this.#config.pronounsConfig.nominative;
+					customPronounsConfig.nominativeExists = true;
 				}
 				if (this.#config.pronounsConfig.objective !== '') {
 					customPronounsConfig.objective = this.#config.pronounsConfig.objective;
+					customPronounsConfig.objectiveExists = true;
 				}
 				if (this.#config.pronounsConfig.possessiveAdjective !== '') {
 					customPronounsConfig.possessiveAdjective =
 						this.#config.pronounsConfig.possessiveAdjective;
+					customPronounsConfig.possessiveAdjectiveExists = true;
 				}
 			}
 			return customPronounsConfig;
 		} else {
-			return BASIC_PRONOUN_CONFIGS[this.#config.pronouns];
+			return { ...BASIC_PRONOUN_CONFIGS[this.#config.pronouns], ...pronounsExist };
 		}
 	}
 
@@ -513,8 +527,11 @@ export class DragonStats {
 
 	pronounsPlural: boolean;
 	pronounNominative: string;
+	pronounNominativeExists: boolean;
 	pronounObjective: string;
+	pronounObjectiveExists: boolean;
 	pronounPossessiveAdjective: string;
+	pronounPossessiveAdjectiveExists: boolean;
 
 	size: Size;
 	type: string;

--- a/src/lib/dragon/index.ts
+++ b/src/lib/dragon/index.ts
@@ -130,6 +130,13 @@ export type PronounsConfig = {
 	objective: string;
 	possessiveAdjective: string;
 };
+
+export type PronounsExistence = {
+	nominativeExists: boolean;
+	objectiveExists: boolean;
+	possessiveAdjectiveExists: boolean;
+};
+
 export const BASIC_PRONOUN_CONFIGS: {
 	[key in BasicPronouns]: PronounsConfig;
 } = {

--- a/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
+++ b/src/lib/dragon/stat-block/actions/ActionChangeShape.svelte
@@ -26,10 +26,10 @@
 			<i><b>Change Shape.</b></i>
 			{dragon.nameUpper} magically transforms into a Humanoid or Beast, or back into
 			{dragon.pronounPossessiveAdjective} true form. Any objects {dragon.pronounNominative}
-			{dragon.pronounsPlural ? 'are' : 'is'} wearing or carrying are absorbed or borne by the new form
-			({dragon.name}'s choice). {dragon.nameUpper} reverts to {dragon.pronounPossessiveAdjective}
+			{dragon.pronounsPlural && dragon.pronounNominativeExists ? 'are' : 'is'} wearing or carrying are
+			absorbed or borne by the new form ({dragon.name}'s choice). {dragon.nameUpper} reverts to {dragon.pronounPossessiveAdjective}
 			true form if {dragon.pronounNominative}
-			{dragon.pronounsPlural ? 'are' : 'is'} reduced to 0 hit points.
+			{dragon.pronounsPlural && dragon.pronounNominativeExists ? 'are' : 'is'} reduced to 0 hit points.
 		</p>
 		<p>
 			In the new form, {dragon.name} retains {dragon.pronounPossessiveAdjective}

--- a/src/lib/dragon/stat-block/actions/breath-weapons/Breath2Red.svelte
+++ b/src/lib/dragon/stat-block/actions/breath-weapons/Breath2Red.svelte
@@ -19,9 +19,9 @@
 		for 1 minute. On each of its turns while <ConditionLink
 			condition="charmed"
 			disabled={disableLinks}
-		/> in this way, the creature must move towards the nearest creature it can see (excluding itself
-		and {dragon.name}) and attack it once, ending its turn after doing so or if unable to. The
-		creature can repeat the saving throw at the end of each of its turns, ending the effect on
+		/> in this way, the creature must move as close as possible to the nearest creature it can see (excluding
+		itself and {dragon.name}) and attack it once, ending its turn after doing so or if unable to.
+		The creature can repeat the saving throw at the end of each of its turns, ending the effect on
 		itself with a success.
 	</p>
 </div>

--- a/src/lib/dragon/stat-block/actions/breath-weapons/Breath2Violet.svelte
+++ b/src/lib/dragon/stat-block/actions/breath-weapons/Breath2Violet.svelte
@@ -24,7 +24,8 @@
 			the space it left or in the nearest unoccupied space if that space is occupied.
 		{:else}
 			As a bonus action, {dragon.name} can unbanish all the creatures {dragon.pronounNominative}
-			{dragon.pronounsPlural ? 'have' : 'has'} banished within the last hour.
+			{dragon.pronounsPlural && dragon.pronounNominativeExists ? 'have' : 'has'} banished within the
+			last hour.
 			{#if dragon.breath2SpecialValue.length > 0}
 				Creatures are automatically unbanished after {dragon.breath2SpecialValue}.
 			{/if}

--- a/src/lib/dragon/stat-block/bonus-actions/BActionVariableRadiance.svelte
+++ b/src/lib/dragon/stat-block/bonus-actions/BActionVariableRadiance.svelte
@@ -42,9 +42,13 @@
 				{penalties}.
 			{/if}
 			{dragon.nameUpper} stops glowing if {dragon.pronounNominative}
-			{dragon.pronounsPlural ? 'die' : 'dies'}, {dragon.pronounsPlural ? 'fall' : 'falls'}
+			{dragon.pronounsPlural && dragon.pronounNominativeExists ? 'die' : 'dies'}, {dragon.pronounsPlural &&
+			dragon.pronounNominativeExists
+				? 'fall'
+				: 'falls'}
 			<ConditionLink condition="unconscious" disabled={disableLinks} />, or
-			{dragon.pronounsPlural ? 'choose' : 'chooses'} to stop as a bonus action.
+			{dragon.pronounsPlural && dragon.pronounNominativeExists ? 'choose' : 'chooses'} to stop as a bonus
+			action.
 		{:else}
 			<i><b>Variable Shadow.</b></i>
 			{dragon.nameUpper} chooses a radius up to {dragon.prismaticRadianceRadius}

--- a/src/lib/dragon/stat-block/features/FeatureWardOfLight.svelte
+++ b/src/lib/dragon/stat-block/features/FeatureWardOfLight.svelte
@@ -12,20 +12,16 @@
 				<i>
 					<b>Ward of Light (1/Day).</b>
 				</i>
-				If {dragon.name} would drop to 0 hit points while glowing with {dragon.pronounPossessiveAdjective}
-				Variable Radiance, {dragon.pronounNominative} can instead drop to 1 hit point and halve the radius
-				of {dragon.pronounPossessiveAdjective}
-				Variable Radiance as {dragon.pronounNominative}
+				If {dragon.name} would drop to 0 hit points while glowing with Variable Radiance, {dragon.pronounNominative}
+				can instead drop to 1 hit point and halve the radius of Variable Radiance as {dragon.pronounNominative}
 				{dragon.pronounsPlural && dragon.pronounNominativeExists ? 'condense' : 'condenses'}
 				light into a fleeting ward.
 			{:else}
 				<i>
 					<b>Ward of Shadow (1/Day).</b>
 				</i>
-				If {dragon.name} would drop to 0 hit points while {dragon.pronounPossessiveAdjective}
-				Variable Shadow is active, {dragon.pronounNominative} can instead drop to 1 hit point and halve
-				the radius of {dragon.pronounPossessiveAdjective}
-				Variable Shadow as {dragon.pronounNominative}
+				If {dragon.name} would drop to 0 hit points while Variable Shadow is active, {dragon.pronounNominative}
+				can instead drop to 1 hit point and halve the radius of Variable Shadow as {dragon.pronounNominative}
 				{dragon.pronounsPlural && dragon.pronounNominativeExists ? 'condense' : 'condenses'}
 				shadow into a fleeting ward.
 			{/if}

--- a/src/lib/dragon/stat-block/features/FeatureWardOfLight.svelte
+++ b/src/lib/dragon/stat-block/features/FeatureWardOfLight.svelte
@@ -16,7 +16,7 @@
 				Variable Radiance, {dragon.pronounNominative} can instead drop to 1 hit point and halve the radius
 				of {dragon.pronounPossessiveAdjective}
 				Variable Radiance as {dragon.pronounNominative}
-				{dragon.pronounsPlural ? 'condense' : 'condenses'}
+				{dragon.pronounsPlural && dragon.pronounNominativeExists ? 'condense' : 'condenses'}
 				light into a fleeting ward.
 			{:else}
 				<i>
@@ -26,7 +26,7 @@
 				Variable Shadow is active, {dragon.pronounNominative} can instead drop to 1 hit point and halve
 				the radius of {dragon.pronounPossessiveAdjective}
 				Variable Shadow as {dragon.pronounNominative}
-				{dragon.pronounsPlural ? 'condense' : 'condenses'}
+				{dragon.pronounsPlural && dragon.pronounNominativeExists ? 'condense' : 'condenses'}
 				shadow into a fleeting ward.
 			{/if}
 		</p>

--- a/src/lib/dragon/stat-block/features/FeatureWardOfLight.svelte
+++ b/src/lib/dragon/stat-block/features/FeatureWardOfLight.svelte
@@ -13,9 +13,8 @@
 					<b>Ward of Light (1/Day).</b>
 				</i>
 				If {dragon.name} would drop to 0 hit points while glowing with {dragon.pronounPossessiveAdjective}
-				Variable Radiance, {dragon.pronounNominative} instead {dragon.pronounsPlural
-					? 'drop'
-					: 'drops'} to 1 hit point and {dragon.pronounsPlural ? 'halve' : 'halves'} the radius of {dragon.pronounPossessiveAdjective}
+				Variable Radiance, {dragon.pronounNominative} can instead drop to 1 hit point and halve the radius
+				of {dragon.pronounPossessiveAdjective}
 				Variable Radiance as {dragon.pronounNominative}
 				{dragon.pronounsPlural ? 'condense' : 'condenses'}
 				light into a fleeting ward.
@@ -24,10 +23,9 @@
 					<b>Ward of Shadow (1/Day).</b>
 				</i>
 				If {dragon.name} would drop to 0 hit points while {dragon.pronounPossessiveAdjective}
-				Variable Shadow is active, {dragon.pronounNominative} instead {dragon.pronounsPlural
-					? 'drop'
-					: 'drops'} to 1 hit point and {dragon.pronounsPlural ? 'halve' : 'halves'}
-				the radius of {dragon.pronounPossessiveAdjective} Variable Shadow as {dragon.pronounNominative}
+				Variable Shadow is active, {dragon.pronounNominative} can instead drop to 1 hit point and halve
+				the radius of {dragon.pronounPossessiveAdjective}
+				Variable Shadow as {dragon.pronounNominative}
 				{dragon.pronounsPlural ? 'condense' : 'condenses'}
 				shadow into a fleeting ward.
 			{/if}

--- a/src/lib/modals/DragonShareModal.svelte
+++ b/src/lib/modals/DragonShareModal.svelte
@@ -23,7 +23,7 @@
 {#if $modalStore[0]}
 	<div class="card p-4 w-modal shadow-xl space-y-4 overflow-x-clip">
 		<header class="text-2xl font-bold">{$modalStore[0].title ?? 'Share Dragon'}</header>
-		<div>
+		<div class="break-words">
 			{shareURL}
 		</div>
 		<slot />


### PR DESCRIPTION
## What's in this PR?
This PR contains the following changes:
- I disabled smooth scrolling because I didn't like it. Disabling it seems to have fixed another issue, one where the page wouldn't always scroll to top after navigation. Win-win.
- The Ward of Light feature is now clearly optional, plus it's been shortened slightly by removing some unneeded pronouns.
- Pronoun pluralization now checks to see if there is actually a pronoun.
- DragonShareModal now wraps the url properly on Chrome.
- Clarified Fury Breath movement since the previous wording left it pretty open.

## 🐢
